### PR TITLE
Add installation readiness check with advice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,5 @@ script-second-script.sh
 #
 **/.claude/settings.local.json
 
-#
+# Private notes / terminal snippets
 README.local.md

--- a/docs/EBPF.MD
+++ b/docs/EBPF.MD
@@ -52,7 +52,7 @@ sudo apt-get install -y linux-headers-$(uname -r)
 ### BPF Tools and Libraries
 
 ```bash
-sudo apt-get install -y libbpf-dev bpftool
+sudo apt-get install -y libbpf-dev linux-hwe-6.5-tools-common
 ```
 
 ### Build Essentials and Dependencies

--- a/src/cli/src/nondaemon_commands.rs
+++ b/src/cli/src/nondaemon_commands.rs
@@ -77,21 +77,11 @@ pub fn print_install_readiness() -> Result<()> {
             "apt-get:build-essential",
         ),
         ("pkg-config", "dpkg -s pkg-config", "apt-get:pkg-config"),
+        ("libelf1", "dpkg -s libelf1", "apt-get:libelf1"),
         ("libelf-dev", "dpkg -s libelf-dev", "apt-get:libelf-dev"),
+        ("zlib1g-dev", "dpkg -s zlib1g-dev", "apt-get:zlib1g-dev"),
         ("llvm", "dpkg -s llvm", "apt-get:llvm"),
         ("clang", "dpkg -s clang", "apt-get:clang"),
-        (
-            "linux-headers",
-            "dpkg -l | grep '^ii' | grep 'linux-headers-'",
-            "apt-get:linux-headers-$(uname -r)",
-        ),
-        ("bpf-linker", "which bpf-linker", "cargo:bpf-linker"),
-        (
-            "bpftool",
-            "which bpftool",
-            "apt-get:linux-hwe-6.5-tools-common",
-        ),
-        ("libbpf-dev", "dpkg -s libbpf-dev", "apt-get:libbpf-dev"),
     ];
 
     for (package_name, check_cmd, install_advice) in &packages {

--- a/src/cli/src/nondaemon_commands.rs
+++ b/src/cli/src/nondaemon_commands.rs
@@ -65,6 +65,127 @@ pub async fn wait(api_client: &DaemonClient) -> Result<()> {
     bail!("Daemon not started yet")
 }
 
+pub fn print_install_readiness() -> Result<()> {
+    let mut diagnostics: Vec<String> = vec![];
+    let mut missing_packages: Vec<String> = vec![];
+    let mut missing_package_advice: Vec<String> = vec![];
+
+    let packages = [
+        (
+            "build-essential",
+            "dpkg -s build-essential",
+            "apt-get:build-essential",
+        ),
+        ("pkg-config", "dpkg -s pkg-config", "apt-get:pkg-config"),
+        ("libelf-dev", "dpkg -s libelf-dev", "apt-get:libelf-dev"),
+        ("llvm", "dpkg -s llvm", "apt-get:llvm"),
+        ("clang", "dpkg -s clang", "apt-get:clang"),
+        (
+            "linux-headers",
+            "dpkg -l | grep '^ii' | grep 'linux-headers-'",
+            "apt-get:linux-headers-$(uname -r)",
+        ),
+        ("bpf-linker", "which bpf-linker", "cargo:bpf-linker"),
+        (
+            "bpftool",
+            "which bpftool",
+            "apt-get:linux-hwe-6.5-tools-common",
+        ),
+        ("libbpf-dev", "dpkg -s libbpf-dev", "apt-get:libbpf-dev"),
+    ];
+
+    for (package_name, check_cmd, install_advice) in &packages {
+        let is_installed = Command::new("sh")
+            .arg("-c")
+            .arg(check_cmd)
+            .output()
+            .map(|output| output.status.success())
+            .unwrap_or(false);
+
+        if !is_installed {
+            missing_packages.push(package_name.to_string());
+            missing_package_advice.push(install_advice.to_string());
+        }
+    }
+
+    if !missing_packages.is_empty() {
+        let mut message = format!(
+            "Found missing packages: {}\n\nTo install them run:\n",
+            missing_packages.join(", ")
+        );
+
+        let mut apt_get_packages = vec![];
+        let mut cargo_packages = vec![];
+
+        for (package_name, _, install_advice) in &packages {
+            if missing_packages.contains(&package_name.to_string()) {
+                if install_advice.starts_with("apt-get:") {
+                    apt_get_packages.push(install_advice.replace("apt-get:", ""));
+                } else if install_advice.starts_with("cargo:") {
+                    cargo_packages.push(install_advice.replace("cargo:", ""));
+                }
+            }
+        }
+
+        if !apt_get_packages.is_empty() {
+            message.push_str(&format!(
+                "sudo apt-get install -y {}\n",
+                apt_get_packages.join(" ")
+            ));
+        }
+
+        if !cargo_packages.is_empty() {
+            message.push_str(&format!("cargo install {}\n", cargo_packages.join(" ")));
+        }
+
+        diagnostics.push(message);
+    }
+
+    // Check kernel version (should be v5.15)
+    let kernel_version = Command::new("uname")
+        .arg("-r")
+        .output()
+        .ok()
+        .and_then(|output| {
+            String::from_utf8(output.stdout).ok().and_then(|version| {
+                let parts: Vec<&str> = version.trim().split('.').collect();
+                if parts.len() >= 2 {
+                    let major = parts[0].parse::<u32>().ok()?;
+                    let minor = parts[1].parse::<u32>().ok()?;
+                    Some((major, minor))
+                } else {
+                    None
+                }
+            })
+        });
+
+    match kernel_version {
+        Some((5, 15)) => {
+            // Kernel version matches
+        }
+        Some((major, minor)) => {
+            diagnostics.push(format!(
+                "Tracer has been tested and confirmed to work on Linux kernel v5.15, detected v{}.{}. Contact support if issues arise.",
+                major, minor
+            ));
+        }
+        None => {
+            diagnostics.push("Linux kernel version unknown. Recommended: v5.15.".to_string());
+        }
+    }
+
+    // Print all collected diagnostics
+    for warning in &diagnostics {
+        println!();
+        println!("{}", warning);
+    }
+    if !&diagnostics.is_empty() {
+        println!();
+    }
+
+    Ok(())
+}
+
 pub async fn print_config_info(api_client: &DaemonClient, config: &Config) -> Result<()> {
     let mut output = String::new();
 

--- a/src/cli/src/process_command.rs
+++ b/src/cli/src/process_command.rs
@@ -1,7 +1,8 @@
 use crate::commands::{Cli, Commands};
 use crate::logging::setup_logging;
 use crate::nondaemon_commands::{
-    clean_up_after_daemon, print_config_info, setup_config, update_tracer, wait,
+    clean_up_after_daemon, print_config_info, print_install_readiness, setup_config, update_tracer,
+    wait,
 };
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -69,6 +70,7 @@ pub fn process_cli() -> Result<()> {
                 match start_daemon() {
                     Outcome::Parent(Ok(_)) => {
                         tokio::runtime::Runtime::new()?.block_on(async {
+                            let _ = print_install_readiness();
                             wait(&api_client).await?;
                             print_config_info(&api_client, &config).await
                         })?;

--- a/src/common/src/target_process/targets_list.rs
+++ b/src/common/src/target_process/targets_list.rs
@@ -636,6 +636,26 @@ pub static ref OPT_CONDA_BIN_EXCEPTIONS : Vec<TargetMatch> = vec![
     TargetMatch::BinPathLastComponent("zstdgrep".to_string()),
     TargetMatch::BinPathLastComponent("zstdless".to_string()),
     TargetMatch::BinPathLastComponent("zstdmt".to_string()),
+    TargetMatch::CommandContains(CommandContainsStruct {
+        process_name: None,
+        command_content: "nextflow".to_string(),
+    }),
+    TargetMatch::CommandContains(CommandContainsStruct {
+        process_name: None,
+        command_content: "nextflow-config".to_string(),
+    }),
+    TargetMatch::CommandContains(CommandContainsStruct {
+        process_name: None,
+        command_content: "nextflow_work".to_string(),
+    }),
+    TargetMatch::CommandContains(CommandContainsStruct {
+        process_name: None,
+        command_content: ".command.sh".to_string(),
+    }),
+    TargetMatch::CommandContains(CommandContainsStruct {
+        process_name: None,
+        command_content: ".command.run".to_string(),
+    }),
     ].to_vec();
 
 pub static ref TARGETS: Vec<Target> = [
@@ -768,6 +788,19 @@ pub static ref DEFAULT_EXCLUDED_PROCESS_RULES : Vec<Target>  = vec![
         process_name: None,
         command_content: ".command.sh".to_string(),
     })),
+    Target::new(TargetMatch::CommandContains(CommandContainsStruct {
+        process_name: None,
+        command_content: ".command.run".to_string(),
+    })),
+    Target::new(TargetMatch::CommandContains(CommandContainsStruct {
+        process_name: Some("bash".into()),
+        command_content: ".command.sh".to_string(),
+    })),
+    Target::new(TargetMatch::CommandContains(CommandContainsStruct {
+        process_name: Some("bash".into()),
+        command_content: ".command.run".to_string(),
+    })),
+
 ].to_vec();
 
 


### PR DESCRIPTION
Ticket: https://linear.app/tracercloud/issue/ENG-308/ebpf-and-other-system-requirement-checks-and-feedback-communication-to (also partially/indirectly addresses ease-of-install aspects of https://linear.app/tracercloud/issue/ENG-307/ebpf-installation-and-different-kernel-compilation-version-support)

Adds diagnostics for missing packages / kernel version mismatch on tracer init:

<img width="831" alt="image" src="https://github.com/user-attachments/assets/fac056b2-635f-43b5-8612-99ca1bf55d18" />

Easy to extend with diagnostics for additional packages:

<img width="468" alt="image" src="https://github.com/user-attachments/assets/8d666f94-d0eb-48b6-a95d-db59892fa4ef" />

I also changed `sudo apt-get install bpftool` to `sudo apt-get linux-hwe-6.5-tools-common`, which includes `bpftool` and is more-reliably available from default Ubuntu apt-get repositories.