### PR TITLE
chore: fix `tracer update` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -2070,7 +2070,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -3307,7 +3307,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -3326,7 +3326,7 @@ dependencies = [
  "rand 0.9.1",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -3555,7 +3555,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -3754,16 +3754,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -3831,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "aws-lc-rs",
  "ring 0.17.14",
@@ -4483,7 +4483,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "serde",
  "serde_json",
  "sha2",
@@ -5005,7 +5005,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.26",
+ "rustls 0.23.27",
  "tokio",
 ]
 
@@ -5157,6 +5157,7 @@ dependencies = [
  "daemonize",
  "octocrab",
  "predicates",
+ "rustls 0.23.27",
  "sentry",
  "sqlx",
  "sysinfo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5151,6 +5151,7 @@ version = "2025.5.15+1"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "clap",
  "colored",
  "console",
@@ -5158,6 +5159,7 @@ dependencies = [
  "octocrab",
  "predicates",
  "rustls 0.23.27",
+ "semver 1.0.26",
  "sentry",
  "sqlx",
  "sysinfo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ octocrab = "0.44.0"
 predicates = "3.1.2"
 random-string = "1.1.0"
 reqwest = { version = "0.12.13", default-features = false, features = ["json", "rustls-tls"] }
+rustls = "0.23.27"
 serde = { version = "1.0", features = ["std", "derive", "serde_derive"] }
 serde_json = "1.0.117"
 sysinfo = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ predicates = "3.1.2"
 random-string = "1.1.0"
 reqwest = { version = "0.12.13", default-features = false, features = ["json", "rustls-tls"] }
 rustls = "0.23.27"
+semver = "1.0.22"
 serde = { version = "1.0", features = ["std", "derive", "serde_derive"] }
 serde_json = "1.0.117"
 sysinfo = "0.30"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -9,11 +9,13 @@ authors = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 daemonize = { workspace = true }
 octocrab = { workspace = true }
 predicates = { workspace = true }
 rustls = { workspace = true }
+semver = { workspace = true }
 sysinfo = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -13,6 +13,7 @@ clap = { workspace = true }
 daemonize = { workspace = true }
 octocrab = { workspace = true }
 predicates = { workspace = true }
+rustls = { workspace = true }
 sysinfo = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -2,6 +2,9 @@ use anyhow::Context;
 use tracer_cli::process_command::process_cli;
 
 pub fn main() -> anyhow::Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map_err(|e| anyhow::anyhow!("Failed to install default crypto provider: {:?}", e))?;
     process_cli().context("Can't process CLI command")?;
     Ok(())
 }

--- a/src/cli/src/nondaemon_commands.rs
+++ b/src/cli/src/nondaemon_commands.rs
@@ -375,7 +375,7 @@ pub async fn update_tracer() -> Result<()> {
     println!("Updating Tracer to version {}", release.tag_name);
 
     let mut command = Command::new("bash");
-    command.arg("-c").arg(format!("curl -sSL https://raw.githubusercontent.com/davincios/tracer-daemon/main/install-tracer.sh | bash -s -- {} && . ~/.bashrc && tracer", config.api_key));
+    command.arg("-c").arg(format!("curl -sSL https://install.tracer.cloud | bash -s -- {} && . ~/.bashrc && tracer", config.api_key));
 
     command
         .status()

--- a/src/cli/src/process_command.rs
+++ b/src/cli/src/process_command.rs
@@ -117,6 +117,10 @@ pub fn process_cli() -> Result<()> {
             result
         }
         Commands::ApplyBashrc => ConfigLoader::setup_aliases(),
+        Commands::Update => {
+            // Handle update command directly without going through daemon
+            tokio::runtime::Runtime::new()?.block_on(update_tracer())
+        }
         _ => {
             match tokio::runtime::Runtime::new()?.block_on(run_async_command(
                 cli.command,

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -8,8 +8,9 @@ pub const DEBUG_LOG: &str = "/tmp/tracer/debug.log";
 
 pub const SYSLOG_FILE: &str = "/var/log/syslog";
 
-pub const REPO_OWNER: &str = "davincios";
-pub const REPO_NAME: &str = "tracer-daemon";
+pub const REPO_OWNER: &str = "tracer-cloud";
+pub const REPO_NAME: &str = "tracer-client";
+
 
 // TODO: remove dependency from Service url completely
 pub const DEFAULT_SERVICE_URL: &str = "https://app.tracer.bio/api";


### PR DESCRIPTION
## 📌 Summary
Fixes & revamps the tracer update command.

## 🔍 Related Issues/Tickets
<img width="1172" alt="Screenshot 2025-05-25 at 10 06 31 PM" src="https://github.com/user-attachments/assets/eb00709e-4c88-46ec-adf2-0b32aca4d9a9" />

## ✨ Changes Introduced
- Fix tracer update command.
- Update tracer installation script URL.
- Change repository owner and name for fetching updates.
- Add a warning before updating tracer, including semantic version comparison of the latest release.


## ✨ Infrastructure Impact
NA

## ✅ Checklist
- [ ] Code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and they work as expected
- [ ] Documentation has been updated if needed
- [ ] Tests have been added or updated

## 🛠️ How to Test
Run `tracer update`

## 🚀 Screenshots (if applicable)
<!-- Add screenshots or GIFs to demonstrate the changes -->


### Latest version

<img width="808" alt="Screenshot 2025-05-25 at 11 10 13 PM" src="https://github.com/user-attachments/assets/797b6d06-f964-4c7c-a8cb-d441a087d6b9" />

### Older Version

<img width="1060" alt="Screenshot 2025-05-25 at 10 59 05 PM" src="https://github.com/user-attachments/assets/ddacd7a3-cc01-45a3-a596-dc3af905503a" />


## 📌 Additional Notes

When copying the installation command from https://app.tracer.bio/onboarding, the displayed onboarding script appears as follows:
<img width="804" alt="Screenshot 2025-05-25 at 11 17 26 PM" src="https://github.com/user-attachments/assets/b7b87a07-2f3c-4fa9-baf1-3368cc2e33e3" />
However, the command that actually gets copied is:

```bash
curl -sSL https://raw.githubusercontent.com/davincios/tracer-daemon/main/install-tracer.sh  | bash -s -- 0a6WJ18AkX9_95b3UOmlD  && . ~/.bashrc && tracer init
```

