### PR TITLE
Bug/fix sentry

### DIFF
--- a/src/tracer/src/commands.rs
+++ b/src/tracer/src/commands.rs
@@ -1,11 +1,12 @@
 use crate::common::types::cli::params::TracerCliInitArgs;
+use crate::utils::version::Version;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser, Clone)]
 #[clap(
     name = "tracer",
     about = "A tool for monitoring bioinformatics applications",
-    version = env!("CARGO_PKG_VERSION")
+    version = Version::current_str()
 )]
 pub struct Cli {
     #[clap(long, global = true)]

--- a/src/tracer/src/common/types/cli/params.rs
+++ b/src/tracer/src/common/types/cli/params.rs
@@ -1,5 +1,6 @@
 use crate::common::types::pipeline_tags::PipelineTags;
 use clap::Args;
+use serde::Serialize;
 
 #[derive(Default, Args, Debug, Clone)]
 pub struct TracerCliInitArgs {
@@ -29,7 +30,7 @@ pub struct TracerCliInitArgs {
 }
 
 /// Ensures the pipeline name remains required
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct FinalizedInitArgs {
     pub pipeline_name: String,
     pub run_id: Option<String>,

--- a/src/tracer/src/config/mod.rs
+++ b/src/tracer/src/config/mod.rs
@@ -1,10 +1,9 @@
 mod defaults;
-
-use serde::{Deserialize, Serialize};
-
 use crate::cloud_providers::aws::config::AwsConfig;
 use crate::cloud_providers::aws::types::aws_region::AwsRegion;
 use crate::common::target_process::Target;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
@@ -31,4 +30,23 @@ pub struct Config {
 
     pub log_forward_endpoint_dev: Option<String>,
     pub log_forward_endpoint_prod: Option<String>,
+}
+
+impl Config {
+    pub fn to_safe_json(&self) -> Value {
+        json!({
+            "process_polling_interval_ms": self.process_polling_interval_ms,
+            "batch_submission_interval_ms": self.batch_submission_interval_ms,
+            "process_metrics_send_interval_ms": self.process_metrics_send_interval_ms,
+            "file_size_not_changing_period_ms": self.file_size_not_changing_period_ms,
+            "new_run_pause_ms": self.new_run_pause_ms,
+            "targets": self.targets,
+            "aws_init_type": self.aws_init_type,
+            "aws_region": self.aws_region,
+            "database_name": self.database_name,
+            "grafana_workspace_url": self.grafana_workspace_url,
+            "server": self.server,
+            "config_sources": self.config_sources,
+        })
+    }
 }

--- a/src/tracer/src/nondaemon_commands.rs
+++ b/src/tracer/src/nondaemon_commands.rs
@@ -229,7 +229,7 @@ pub async fn update_tracer() -> Result<()> {
         .get_latest()
         .await?;
 
-    let current = env!("CARGO_PKG_VERSION");
+    let current = Version::current_str();
     let latest = &release.tag_name;
 
     let current_ver: Version = current.parse().ok().unwrap();

--- a/src/tracer/src/utils/info_formatter.rs
+++ b/src/tracer/src/utils/info_formatter.rs
@@ -1,6 +1,7 @@
 use crate::common::constants::{LOG_FILE, STDERR_FILE, STDOUT_FILE};
 use crate::config::Config;
 use crate::daemon::structs::{InfoResponse, InnerInfoResponse};
+use crate::utils::version::Version;
 use anyhow::Result;
 use colored::Colorize;
 use console::Emoji;
@@ -117,7 +118,7 @@ impl InfoFormatter {
         self.add_header("TRACER CLI STATUS")?;
         self.add_empty_line()?;
         self.add_status_field("Daemon Status", "Not Started", "inactive")?;
-        self.add_field("Version", env!("CARGO_PKG_VERSION"), "bold")?;
+        self.add_field("Version", Version::current_str(), "bold")?;
         self.add_empty_line()?;
         self.add_section_header("NEXT STEPS")?;
         self.add_empty_line()?;
@@ -138,7 +139,7 @@ impl InfoFormatter {
         self.add_section_header("DAEMON STATUS")?;
         self.add_empty_line()?;
         self.add_status_field("Status", "Running", "active")?;
-        self.add_field("Version", env!("CARGO_PKG_VERSION"), "bold")?;
+        self.add_field("Version", Version::current_str(), "bold")?;
         self.add_empty_line()?;
         Ok(())
     }

--- a/src/tracer/src/utils/mod.rs
+++ b/src/tracer/src/utils/mod.rs
@@ -1,6 +1,6 @@
 pub mod info_formatter;
-pub mod version;
 mod sentry;
+pub mod version;
 use crate::common::types::analytics::{AnalyticsEventType, AnalyticsPayload};
 use crate::constants::TRACER_ANALYTICS_ENDPOINT;
 use anyhow::Context;

--- a/src/tracer/src/utils/mod.rs
+++ b/src/tracer/src/utils/mod.rs
@@ -1,10 +1,11 @@
 pub mod info_formatter;
 pub mod version;
-
+mod sentry;
 use crate::common::types::analytics::{AnalyticsEventType, AnalyticsPayload};
 use crate::constants::TRACER_ANALYTICS_ENDPOINT;
 use anyhow::Context;
 use reqwest::Client;
+pub use sentry::Sentry;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;

--- a/src/tracer/src/utils/sentry.rs
+++ b/src/tracer/src/utils/sentry.rs
@@ -1,23 +1,51 @@
 use crate::config::Config;
-use crate::utils::version::Version;
+use sentry::protocol::Context;
 use sentry::ClientOptions;
+use serde_json::Value;
+use std::collections::BTreeMap;
 
 pub struct Sentry;
 
-impl Sentry{
-    pub fn setup(config: &Config) -> Option<sentry::ClientInitGuard>{
-        if !cfg!(test) || config.sentry_dsn.is_none() {        return None;    }
+impl Sentry {
+    /// Initializes Sentry if a DSN is provided in the config.
+    /// Returns a guard to keep Sentry active for the program's lifetime.
+    pub fn setup(config: &Config) -> Option<sentry::ClientInitGuard> {
+        let sentry = sentry::init((
+            config.sentry_dsn.as_deref()?,
+            ClientOptions {
+                release: sentry::release_name!(),
+                // Enables capturing user IPs and sensitive headers when using HTTP server integrations.
+                // See: https://docs.sentry.io/platforms/rust/data-management/data-collected/
+                send_default_pii: true,
+                ..Default::default()
+            },
+        ));
 
-        let sentry_dsn = config.sentry_dsn.as_deref().unwrap();
-        let release = format!("tracer@{}",Version::current_str());
-        let sentry = sentry::init((sentry_dsn, ClientOptions {
-            release: Some(release.into()),
-            // Capture user IPs and potentially sensitive headers when using HTTP server integrations
-            // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
-            send_default_pii: true,
-            ..Default::default()
-        }));
-
+        Sentry::add_extra("Config", config.to_safe_json());
         Some(sentry)
+    }
+
+    /// Adds a tag (key-value pair) to the Sentry event for short, string-based metadata.
+    pub fn add_tag(key: &str, value: &str) {
+        sentry::configure_scope(|scope| {
+            scope.set_tag(key, value);
+        });
+    }
+
+    /// Adds a context (flat JSON object) to the Sentry event.
+    /// Requirements:
+    ///   - The value must not be nested.
+    pub fn add_context(key: &str, value: BTreeMap<String, Value>) {
+        sentry::configure_scope(|scope| {
+            scope.set_context(key, Context::Other(value));
+        });
+    }
+
+    /// Adds extra data (arbitrary JSON) to the Sentry event.
+    /// Suitable for long or complex JSON values.
+    pub fn add_extra(key: &str, value: Value) {
+        sentry::configure_scope(|scope| {
+            scope.set_extra(key, value);
+        });
     }
 }

--- a/src/tracer/src/utils/sentry.rs
+++ b/src/tracer/src/utils/sentry.rs
@@ -1,0 +1,23 @@
+use crate::config::Config;
+use crate::utils::version::Version;
+use sentry::ClientOptions;
+
+pub struct Sentry;
+
+impl Sentry{
+    pub fn setup(config: &Config) -> Option<sentry::ClientInitGuard>{
+        if !cfg!(test) || config.sentry_dsn.is_none() {        return None;    }
+
+        let sentry_dsn = config.sentry_dsn.as_deref().unwrap();
+        let release = format!("tracer@{}",Version::current_str());
+        let sentry = sentry::init((sentry_dsn, ClientOptions {
+            release: Some(release.into()),
+            // Capture user IPs and potentially sensitive headers when using HTTP server integrations
+            // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
+            send_default_pii: true,
+            ..Default::default()
+        }));
+
+        Some(sentry)
+    }
+}

--- a/src/tracer/src/utils/version.rs
+++ b/src/tracer/src/utils/version.rs
@@ -11,6 +11,15 @@ pub struct Version {
     build: Option<u32>,
 }
 
+impl Version {
+    pub fn current_str() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+    pub fn current() -> Self {
+        Self::from_str(Self::current_str()).unwrap()
+    }
+}
+
 impl FromStr for Version {
     type Err = String;
 


### PR DESCRIPTION
## 📌 Summary
<!-- Provide a concise summary of your changes -->
Refactored the current Sentry implementation into its own module for future extensibility/usage.
Originally contained in the process_cli method directly.

Unfortunately config & Tracer Init Args will only show on sentry directly as it contains too much information
However tags should be able to show directly on the slack integration
![image](https://github.com/user-attachments/assets/36d74566-e89e-45d1-95ae-67bb440dafdd)

## 🔍 Related Issues/Tickets
<!-- Link to related issues or tickets, e.g., Closes #123 -->
Closes ENG-552
## ✨ Changes Introduced
<!-- Briefly describe the changes in this PR -->
Moved Sentry code into separate utils module.
Provided methods for Sentry to add more tags, extras and contexts throughout the execution of the code and runtime
