### PR TITLE
fix: grafana url and add short link to redirect directly to dashboard

### DIFF
--- a/infrastructure/one-command-infra-provisioning/initialize.sh
+++ b/infrastructure/one-command-infra-provisioning/initialize.sh
@@ -42,7 +42,7 @@ aws_region = "us-east-2"
 database_secrets_arn = "${database_secret_manager_arn}"
 database_host = "${db_endpoint}"
 database_name = "${database_name}"
-grafana_workspace_url = "${grafana_workspace_url}"
+grafana_base_url = "${grafana_base_url}"
 sentry_dsn = "https://35e0843e6748d2c93dfd56716f2eecfe@o4509281671380992.ingest.us.sentry.io/4509281680949248"
 EOL
 

--- a/src/tracer/src/config/defaults.rs
+++ b/src/tracer/src/config/defaults.rs
@@ -3,7 +3,7 @@ use crate::common::constants::DEFAULT_DAEMON_PORT;
 use crate::config::Config;
 use crate::constants::{
     AWS_REGION, BATCH_SUBMISSION_INTERVAL_MS, DEFAULT_API_KEY, FILE_SIZE_NOT_CHANGING_PERIOD_MS,
-    GRAFANA_WORKSPACE_URL, LOG_FORWARD_ENDPOINT_DEV, LOG_FORWARD_ENDPOINT_PROD, NEW_RUN_PAUSE_MS,
+    GRAFANA_BASE_URL, LOG_FORWARD_ENDPOINT_DEV, LOG_FORWARD_ENDPOINT_PROD, NEW_RUN_PAUSE_MS,
     PROCESS_METRICS_SEND_INTERVAL_MS, PROCESS_POLLING_INTERVAL_MS, SENTRY_DSN,
 };
 
@@ -42,7 +42,7 @@ impl Default for Config {
             database_host: None,
             database_name: "tracer_db".to_string(),
 
-            grafana_workspace_url: GRAFANA_WORKSPACE_URL.to_string(),
+            grafana_base_url: GRAFANA_BASE_URL.to_string(),
             server: format!("127.0.0.1:{}", DEFAULT_DAEMON_PORT),
 
             config_sources: vec![],

--- a/src/tracer/src/config/mod.rs
+++ b/src/tracer/src/config/mod.rs
@@ -22,7 +22,7 @@ pub struct Config {
     pub database_host: Option<String>,
     pub database_name: String,
 
-    pub grafana_workspace_url: String,
+    pub grafana_base_url: String,
     pub server: String,
 
     pub config_sources: Vec<String>,
@@ -43,7 +43,7 @@ impl Config {
             "aws_init_type": self.aws_init_type.to_string(),
             "aws_region": self.aws_region,
             "database_name": self.database_name,
-            "grafana_workspace_url": self.grafana_workspace_url,
+            "grafana_base_url": self.grafana_base_url,
             "server": self.server
         })
     }

--- a/src/tracer/src/constants.rs
+++ b/src/tracer/src/constants.rs
@@ -11,6 +11,7 @@ pub const LOG_FORWARD_ENDPOINT_DEV: &str = "https://sandbox.tracer.cloud/api/log
 pub const LOG_FORWARD_ENDPOINT_PROD: &str = "https://sandbox.tracer.cloud/api/logs-forward/prod";
 pub const SENTRY_DSN: &str = "https://35e0843e6748d2c93dfd56716f2eecfe@o4509281671380992.ingest.us.sentry.io/4509281680949248";
 pub const GRAFANA_WORKSPACE_URL: &str = "https://tracerbio.grafana.net/goto/mYJ52c-HR?orgId=1";
+pub const GRAFANA_BASE_URL: &str = "https://tracer.vaibhavupreti.me";
 pub const AWS_REGION: AwsRegion = UsEast2;
 
 pub const TRACER_ANALYTICS_ENDPOINT: &str = "https://sandbox.tracer.cloud/api/analytics";

--- a/src/tracer/src/nondaemon_commands.rs
+++ b/src/tracer/src/nondaemon_commands.rs
@@ -171,7 +171,7 @@ pub fn print_install_readiness() -> Result<()> {
 }
 
 pub async fn print_config_info(api_client: &DaemonClient, config: &Config) -> Result<()> {
-    let mut formatter = InfoFormatter::new(90);
+    let mut formatter = InfoFormatter::new(100);
     let info = match api_client.send_info_request().await {
         Ok(info) => info,
         Err(e) => {
@@ -188,7 +188,7 @@ pub async fn print_config_info(api_client: &DaemonClient, config: &Config) -> Re
     formatter.print_daemon_status()?;
 
     if let Some(inner) = &info.inner {
-        formatter.print_pipeline_info(inner, &info)?;
+        formatter.print_pipeline_info(inner, &info, config)?;
     }
 
     formatter.print_config_and_logs(config)?;


### PR DESCRIPTION
Fixes:
- Grafana dashboard url is broken in `tracer info` due to recent changes to dashboard.
- Adds a short url service to directly redirect the respective dashboard. Eg, try out

https://tracer.vaibhavupreti.me/p/demo_pipeline
https://tracer.vaibhavupreti.me/r/28ec78db-bb9b-46b4-aa6d-3b30da199fb7

<img width="958" alt="Screenshot 2025-06-22 at 12 24 39 AM" src="https://github.com/user-attachments/assets/010995c8-b210-4827-8863-45bb873cf85f" />


## Todo:
- Migrate url to tracer.bio