### PR TITLE
fix: nextflow error aws launch template

### DIFF
--- a/infrastructure/launch-template/main.tf
+++ b/infrastructure/launch-template/main.tf
@@ -12,14 +12,10 @@ data "aws_vpc" "default" {
   default = true
 }
 
-
-
-
 provider "aws" {
   region  = var.region
   profile = "default"
 }
-
 
 module "ec2_common" {
   source      = "../modules/ec2_common"
@@ -34,8 +30,8 @@ module "ec2_common" {
 # ---------------------------
 resource "aws_launch_template" "tracer_launch_template" {
   name_prefix   = "tracer-launch-template"
-  image_id      = "ami-02548ded9f4d4b199" #"ami-08963412c7663a4b8"
-  instance_type = "c6g.2xlarge"           #"c5d.large"         
+  image_id      = var.ami_id
+  instance_type = var.instance_type
 
   key_name = var.perm_key
 

--- a/infrastructure/launch-template/setup-tracer.sh
+++ b/infrastructure/launch-template/setup-tracer.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 set -e
 
-echo "Updating Repositories $(date)"
-cd /root/tracer-test-pipelines-bioinformatics && git pull origin main && cd
-echo "Repositories Updated Successfully $(date)"
+echo "Starting Tracer setup at $(date)"
 
 # Accept role ARN and API key from Terraform environment
-echo "Setting up Tracer"
+echo "Setting up Tracer with role ARN: ${role_arn}"
 
 # Create the config directory
 mkdir -p /root/.config/tracer/
@@ -30,10 +28,37 @@ chmod +x /usr/local/bin/tracer
 
 echo "Tracer binary updated successfully"
 
+# Check if bioinformatics pipeline repository exists
+if [ -d "/root/tracer-test-pipelines-bioinformatics" ]; then
+    echo "Bioinformatics pipeline repository found, updating..."
+    cd /root/tracer-test-pipelines-bioinformatics && git pull origin main && cd
+    echo "Bioinformatics pipeline updated successfully"
+else
+    echo "Bioinformatics pipeline repository not found, cloning..."
+    cd /root && git clone https://github.com/Tracer-Cloud/tracer-test-pipelines-bioinformatics.git --recurse-submodules
+    echo "Bioinformatics pipeline cloned successfully"
+fi
+
+# Check if workflow templates exist in root and create if needed
+if [ ! -d "/root/bashrc_scripts/shell-tracer-autoinstrumentation" ]; then
+    echo "Setting up workflow templates in root directory..."
+    mkdir -p /root/{bashrc_scripts,nextflow_scripts,data}
+        
+    cp -R /tmp/temp-scripts/shell-tracer-autoinstrumentation/ /root/bashrc_scripts/
+    cp -R /tmp/temp-scripts/nextflow-tracer-autoinstrumentation/ /root/nextflow_scripts/
+    cp -R /tmp/temp-scripts/data/ /root/data/
+    
+    rm -rf /tmp/temp-scripts
+    chmod -R +x /root/bashrc_scripts
+    chmod -R +x /root/nextflow_scripts
+    echo "Workflow templates setup completed in root directory"
+fi
+
 # Source bashrc
 source ~/.bashrc
 
 # Run tracer as root
 tracer info
 
-echo "Tracer setup successfully at $(date)"
+echo "Tracer setup completed successfully at $(date)"
+echo "Bioinformatics environment is ready for use"

--- a/infrastructure/launch-template/terraform.tfvars.example
+++ b/infrastructure/launch-template/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# Copy this file to terraform.tfvars and update with your values
+
+# AWS region for deployment
+region = "us-east-1"
+
+# Tracer API key
+api_key = "your-actual-tracer-api-key-here"
+
+# SSH key pair name for instance access
+perm_key = "tracer-from-ami"
+
+# AMI ID with pre-configured bioinformatics tools
+# Update this when you create a new AMI with updated tools
+ami_id = "ami-0dcbd591823292f6a"
+
+# EC2 instance type
+instance_type = "c6g.2xlarge" 

--- a/infrastructure/launch-template/variable.tf
+++ b/infrastructure/launch-template/variable.tf
@@ -3,7 +3,6 @@ variable "region" {
   default     = "us-east-1"
 }
 
-
 variable "api_key" {
   description = "API key for Tracer service"
   type        = string
@@ -15,4 +14,16 @@ variable "perm_key" {
   description = "Permission Key for accessing the instance"
   type        = string
   default     = "tracer-from-ami"
+}
+
+variable "ami_id" {
+  description = "AMI ID for the launch template. Should be pre-configured with bioinformatics tools"
+  type        = string
+  default     = "ami-0dcbd591823292f6a" # Latest AMI with bioinformatics tools
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the launch template"
+  type        = string
+  default     = "c6g.2xlarge"
 }


### PR DESCRIPTION
## 📌 Summary
Fixes:
- Nextflow installation error in aws launch template.
- Adds pixi and spack to default ami for the launch template.

## 🔍 Related Issues/Tickets
ENG-530, ENG-511

## ✨ Changes Introduced
All deps are now pre configured when you do `sudo su` which activates the conda env.

## ✨ Infrastructure Impact


## ✅ Checklist
- [ ] Code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and they work as expected
- [ ] Documentation has been updated if needed
- [ ] Tests have been added or updated

## 🛠️ How to Test
Go to aws and launch a new template from tracer-test-templates version v7.

## 🚀 Screenshots (if applicable)
All deps are now pre configured when you do `sudo su` 

<img width="1074" alt="Screenshot 2025-06-23 at 7 20 13 AM" src="https://github.com/user-attachments/assets/a5a52238-72a4-48ce-bbd0-c8543755a994" />

