### PR TITLE
Add git hash and dirty repo info to version

### DIFF
--- a/.github/workflows/cross-platform-release-and-assets-upload-on-s3.yml
+++ b/.github/workflows/cross-platform-release-and-assets-upload-on-s3.yml
@@ -43,25 +43,6 @@ jobs:
           submodules: recursive # This will fetch all submodules recursively
           fetch-depth: 0 # Fetch all history for versioning
 
-      - name: Update version in Cargo.toml
-        run: |
-          # Get current date in YYYY.MM.DD format
-          DATE=$(date +'%Y.%-m.%-d')
-          # Get short commit hash
-          COMMIT_HASH=$(git rev-parse --short HEAD)
-          # Get time in HH.MM format
-          TIME=$(date +'%H.%M')
-          # Create new version string
-          NEW_VERSION="${DATE}+${TIME}.${COMMIT_HASH}"
-          # Update version in Cargo.toml (compatible with both macOS and Linux)
-          if [[ "${{ matrix.runner }}" == *"macos"* ]]; then
-            sed -i '' "s/^version = \".*\"/version = \"${NEW_VERSION}\"/" Cargo.toml
-          else
-            sed -i "s/^version = \".*\"/version = \"${NEW_VERSION}\"/" Cargo.toml
-          fi
-          # Print the new version for verification
-          echo "Updated version to: ${NEW_VERSION}"
-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cross-platform-release.yml
+++ b/.github/workflows/cross-platform-release.yml
@@ -31,22 +31,6 @@ jobs:
           submodules: recursive # This will fetch all submodules recursively
           fetch-depth: 0 # Fetch all history for versioning
 
-      - name: Update version in Cargo.toml
-        run: |
-          # Extract version from git tag (remove 'v' prefix)
-          TAG_VERSION=${{ github.ref_name }}
-          NEW_VERSION=${TAG_VERSION#v}
-
-          # Update version in Cargo.toml (compatible with both macOS and Linux)
-          if [[ "${{ matrix.runner }}" == *"macos"* ]]; then
-            sed -i '' "s/^version = \".*\"/version = \"${NEW_VERSION}\"/" Cargo.toml
-          else
-            sed -i "s/^version = \".*\"/version = \"${NEW_VERSION}\"/" Cargo.toml
-          fi
-
-          # Print the new version for verification
-          echo "Updated version to: ${NEW_VERSION} (from tag: ${TAG_VERSION})"
-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 dependencies = [
+ "chrono",
  "git2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+dependencies = [
+ "git2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +1719,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "git2"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,6 +2361,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.2+1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,6 +2405,18 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4871,6 +4917,7 @@ dependencies = [
  "aws-sdk-secretsmanager",
  "axum",
  "bollard",
+ "built",
  "chrono",
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,3 +92,4 @@ shlex = "1.3.0"
 yaml-rust2 = "0.10.3"
 pretty_assertions_sorted = "1.2.3"
 bollard = "0.19.0"
+built = { version = "0.8.0", features = ["git2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,4 +92,4 @@ shlex = "1.3.0"
 yaml-rust2 = "0.10.3"
 pretty_assertions_sorted = "1.2.3"
 bollard = "0.19.0"
-built = { version = "0.8.0", features = ["git2"] }
+built = { version = "0.8.0", features = ["chrono", "git2"] }

--- a/src/tracer/Cargo.toml
+++ b/src/tracer/Cargo.toml
@@ -64,3 +64,6 @@ serial_test = { workspace = true }
 uuid = { workspace = true }
 rstest = { workspace = true }
 pretty_assertions_sorted = { workspace = true }
+
+[build-dependencies]
+built = { workspace = true }

--- a/src/tracer/build.rs
+++ b/src/tracer/build.rs
@@ -2,4 +2,6 @@ fn main() {
     // useful to trigger changes in the cargo build on the json file
     println!("cargo:rerun-if-changed=src/process_identification/target_process/yml_rules/tracer.rules.yml");
     println!("cargo:rerun-if-changed=src/process_identification/target_process/yml_rules/tracer.exclude.yml");
+    // write the build-time information to the file
+    built::write_built_file().expect("Failed to acquire build-time information");
 }

--- a/src/tracer/src/process_command.rs
+++ b/src/tracer/src/process_command.rs
@@ -17,7 +17,7 @@ use crate::process_identification::debug_log::Logger;
 use crate::utils::analytics::emit_analytic_event;
 use crate::utils::file_system::ensure_file_can_be_created;
 use crate::utils::system_info::check_sudo_privileges;
-use crate::utils::Sentry;
+use crate::utils::{FullVersion, Sentry};
 use anyhow::{Context, Result};
 use clap::Parser;
 use daemonize::{Daemonize, Outcome};
@@ -351,6 +351,9 @@ pub async fn run_async_command(
         Commands::CleanupPort { port } => {
             let port = port.unwrap_or(DEFAULT_DAEMON_PORT); // Default Tracer port
             handle_port_conflict(port).await?;
+        }
+        Commands::Version => {
+            println!("{}", FullVersion::current_str());
         }
         _ => {
             println!("Command not implemented yet");

--- a/src/tracer/src/process_command.rs
+++ b/src/tracer/src/process_command.rs
@@ -353,7 +353,7 @@ pub async fn run_async_command(
             handle_port_conflict(port).await?;
         }
         Commands::Version => {
-            println!("{}", FullVersion::current_str());
+            println!("{}", FullVersion::current());
         }
         _ => {
             println!("Command not implemented yet");

--- a/src/tracer/src/utils/info_formatter.rs
+++ b/src/tracer/src/utils/info_formatter.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::daemon::structs::{InfoResponse, InnerInfoResponse};
 use crate::process_identification::constants::{LOG_FILE, STDERR_FILE, STDOUT_FILE};
-use crate::utils::version::Version;
+use crate::utils::version::FullVersion;
 use anyhow::Result;
 use colored::Colorize;
 use console::Emoji;
@@ -118,7 +118,7 @@ impl InfoFormatter {
         self.add_header("TRACER CLI STATUS")?;
         self.add_empty_line()?;
         self.add_status_field("Daemon Status", "Not Started", "inactive")?;
-        self.add_field("Version", Version::current_str(), "bold")?;
+        self.add_field("Version", &FullVersion::current_str(), "bold")?;
         self.add_empty_line()?;
         self.add_section_header("NEXT STEPS")?;
         self.add_empty_line()?;
@@ -139,7 +139,7 @@ impl InfoFormatter {
         self.add_section_header("DAEMON STATUS")?;
         self.add_empty_line()?;
         self.add_status_field("Status", "Running", "active")?;
-        self.add_field("Version", Version::current_str(), "bold")?;
+        self.add_field("Version", &FullVersion::current_str(), "bold")?;
         self.add_empty_line()?;
         Ok(())
     }

--- a/src/tracer/src/utils/info_formatter.rs
+++ b/src/tracer/src/utils/info_formatter.rs
@@ -118,7 +118,7 @@ impl InfoFormatter {
         self.add_header("TRACER CLI STATUS")?;
         self.add_empty_line()?;
         self.add_status_field("Daemon Status", "Not Started", "inactive")?;
-        self.add_field("Version", &FullVersion::current_str(), "bold")?;
+        self.add_field("Version", &FullVersion::current().to_string(), "bold")?;
         self.add_empty_line()?;
         self.add_section_header("NEXT STEPS")?;
         self.add_empty_line()?;
@@ -139,7 +139,7 @@ impl InfoFormatter {
         self.add_section_header("DAEMON STATUS")?;
         self.add_empty_line()?;
         self.add_status_field("Status", "Running", "active")?;
-        self.add_field("Version", &FullVersion::current_str(), "bold")?;
+        self.add_field("Version", &FullVersion::current().to_string(), "bold")?;
         self.add_empty_line()?;
         Ok(())
     }

--- a/src/tracer/src/utils/mod.rs
+++ b/src/tracer/src/utils/mod.rs
@@ -1,7 +1,7 @@
 mod info_formatter;
 pub use info_formatter::InfoFormatter;
 mod version;
-pub use version::Version;
+pub use version::{FullVersion, Version};
 mod sentry;
 pub use sentry::Sentry;
 pub mod analytics;

--- a/src/tracer/src/utils/version.rs
+++ b/src/tracer/src/utils/version.rs
@@ -118,8 +118,11 @@ impl FullVersion {
     pub fn current() -> &'static Self {
         static VERSION: Lazy<FullVersion> = Lazy::new(|| {
             let (date, hash, dirty) = if PROFILE != "release" {
+                let date = DateTime::parse_from_rfc2822(BUILT_TIME_UTC)
+                    .unwrap()
+                    .with_timezone(&Utc);
                 (
-                    Some(BUILT_TIME_UTC.parse().unwrap()),
+                    Some(date),
                     Some(GIT_COMMIT_HASH_SHORT.unwrap().to_string()),
                     Some(GIT_DIRTY.unwrap_or(false)),
                 )
@@ -139,7 +142,11 @@ impl FullVersion {
 
 impl fmt::Display for FullVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match (&self.date, &self.hash, self.dirty) {
+        match (
+            &self.date.map(|d| d.format("%Y.%m.%d-%H.%M").to_string()),
+            &self.hash,
+            self.dirty,
+        ) {
             (Some(date), Some(hash), Some(true)) => {
                 write!(f, "{}-{}-{}-dirty", self.version, date, hash)
             }

--- a/src/tracer/src/utils/version.rs
+++ b/src/tracer/src/utils/version.rs
@@ -115,8 +115,8 @@ pub struct FullVersion {
 impl FullVersion {
     pub fn current() -> &'static Self {
         static VERSION: Lazy<FullVersion> = Lazy::new(|| {
-            let hash = if PROFILE != "release" && GIT_COMMIT_HASH.is_some() {
-                Some(GIT_COMMIT_HASH.unwrap().to_string())
+            let hash = if PROFILE != "release" && GIT_COMMIT_HASH_SHORT.is_some() {
+                Some(GIT_COMMIT_HASH_SHORT.unwrap().to_string())
             } else {
                 None
             };


### PR DESCRIPTION
## 📌 Summary
This PR adds [built](https://docs.rs/built/latest/built/) as a build-time dependency, and updates the build script to generate a `built.rs` file that contains constants for [many build-time variables](https://docs.rs/built/latest/built/#always-available). This file is then loaded in `version.rs` to get the package version and also the build profile and git information. This information is held in the new `FullVersion` type, which is now used everywhere to get the version string. gIf the build profile is not `release`, then the git hash is added to the version.

In addition, if the local repo contains uncommitted changes, the `-dirty` suffix is also added. This PR also implements the `version` command. The version reported by `tracer -V` is always just the semver information (`major.minor.patch+build`), but `tracer version` shows the git info as well.

<img width="256" alt="image" src="https://github.com/user-attachments/assets/4e8b5837-2f1b-45b1-84b7-a38cd98139f7" />

## 🔍 Related Issues/Tickets
ENG-482

## ✨ Infrastructure Impact
This changes the build version displayed by `tracer info` when the build profile is not `release`.

<img width="665" alt="image" src="https://github.com/user-attachments/assets/9ae52266-444a-49cf-94a0-ea64a157943d" />

## ✅ Checklist
- [x] Code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and they work as expected
- [ ] Documentation has been updated if needed
- [ ] Tests have been added or updated
