### PR TITLE
Recognize pipeline steps from processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
 dependencies = [
- "convert_case",
+ "convert_case 0.6.0",
  "pathdiff",
  "serde",
  "toml",
@@ -1045,6 +1045,15 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -2590,6 +2599,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi_index_map"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2921dd3396771d28d081e93dbb62dc62e14ee4fe63978c6528e177ad0c6bfe"
+dependencies = [
+ "multi_index_map_derive",
+ "rustc-hash 2.1.1",
+ "slab",
+]
+
+[[package]]
+name = "multi_index_map_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa5e48a85384b125f486e729dbec5bd5e4a255318dd5fe1db772e2224b1234c"
+dependencies = [
+ "convert_case 0.8.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3092,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4934,6 +4989,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mockall",
+ "multi_index_map",
  "octocrab",
  "once_cell",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,4 +93,5 @@ yaml-rust2 = "0.10.3"
 pretty_assertions_sorted = "1.2.3"
 bollard = "0.19.0"
 built = { version = "0.8.0", features = ["chrono", "git2"] }
+multi_index_map = "0.15.0"
 lazy_static = "1.5.0"

--- a/src/tracer/Cargo.toml
+++ b/src/tracer/Cargo.toml
@@ -57,6 +57,7 @@ lazy_static = { workspace = true }
 shlex = { workspace = true }
 bollard = { workspace = true }
 futures-util = { workspace = true }
+multi_index_map = { workspace = true }
 
 [dev-dependencies]
 sqlx = { workspace = true }

--- a/src/tracer/src/extracts/process/process_manager/handlers/process_starts.rs
+++ b/src/tracer/src/extracts/process/process_manager/handlers/process_starts.rs
@@ -28,11 +28,10 @@ impl ProcessStartHandler {
         if matched_processes.is_empty() {
             debug!("No matching processes found; exiting early.");
         } else {
-            // Refresh system data for matched processes
             Self::refresh_process_data(system_refresher, &matched_processes).await?;
-            // Log data for each matched process
+
             Self::log_matched_processes(logger, system_refresher, &matched_processes).await?;
-            // 
+
             Self::update_monitoring(state_manager, matched_processes).await?;
 
             debug!("Process start handling completed successfully.");

--- a/src/tracer/src/extracts/process/process_manager/handlers/process_starts.rs
+++ b/src/tracer/src/extracts/process/process_manager/handlers/process_starts.rs
@@ -23,7 +23,7 @@ impl ProcessStartHandler {
 
         Self::store_triggers(state_manager, triggers.clone()).await;
 
-        let matched_processes = Self::match_processes(state_manager, matcher, triggers).await?;
+        let matched_processes = Self::match_processes(state_manager, matcher, triggers).await;
 
         if matched_processes.is_empty() {
             debug!("No matching processes found; exiting early.");
@@ -57,7 +57,7 @@ impl ProcessStartHandler {
         state_manager: &StateManager,
         matcher: &Filter,
         triggers: Vec<ProcessStartTrigger>,
-    ) -> Result<HashMap<String, HashSet<ProcessStartTrigger>>> {
+    ) -> HashMap<String, HashSet<ProcessStartTrigger>> {
         debug!(
             "Matching {} stored triggers against targets.",
             triggers.len()

--- a/src/tracer/src/extracts/process/process_manager/matcher.rs
+++ b/src/tracer/src/extracts/process/process_manager/matcher.rs
@@ -1,13 +1,13 @@
 use crate::extracts::process::types::process_state::ProcessState;
 use crate::process_identification::target_process::target::Target;
 use crate::process_identification::utils::log_matched_process;
-use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 use tracer_ebpf::ebpf_trigger::ProcessStartTrigger;
 
 /// Handles filtering and matching processes against targets
 /// Gets targets from the ProcessState instead of holding its own copy
 pub struct Filter;
+
 impl Filter {
     pub fn new() -> Self {
         Self
@@ -19,24 +19,28 @@ impl Filter {
         &self,
         triggers: Vec<ProcessStartTrigger>,
         state: &ProcessState,
-    ) -> Result<HashMap<String, HashSet<ProcessStartTrigger>>> {
-        let mut matched_processes = HashMap::new();
-
-        for trigger in triggers {
-            if let Some(matched_target) = state.get_target_manager().get_target_match(&trigger) {
-                log_matched_process(&trigger, &matched_target, true);
-
-                let matched_target = matched_target.clone();
-                matched_processes
-                    .entry(matched_target)
-                    .or_insert(HashSet::new())
-                    .insert(trigger);
-            } else {
-                log_matched_process(&trigger, "", false);
-            }
-        }
-
-        Ok(matched_processes)
+    ) -> HashMap<String, HashSet<ProcessStartTrigger>> {
+        triggers
+            .into_iter()
+            .flat_map(|trigger| {
+                let target = state.get_target_manager().get_target_match(&trigger);
+                if let Some(rule) = &target {
+                    log_matched_process(&trigger, rule, true);
+                } else {
+                    log_matched_process(&trigger, "", false);
+                }
+                target.map(|target| (trigger, target))
+            })
+            .fold(
+                HashMap::new(),
+                |mut matched_processes, (trigger, matched_target)| {
+                    matched_processes
+                        .entry(matched_target)
+                        .or_insert(HashSet::new())
+                        .insert(trigger);
+                    matched_processes
+                },
+            )
     }
 
     /// Collects all PIDs from the filtered target processes map
@@ -50,6 +54,7 @@ impl Filter {
             .collect()
     }
 }
+
 impl Default for Filter {
     fn default() -> Self {
         Self::new()

--- a/src/tracer/src/process_identification/mod.rs
+++ b/src/tracer/src/process_identification/mod.rs
@@ -1,7 +1,8 @@
 pub mod constants;
 pub mod debug_log;
 pub mod recorder; // todo: this is very ugly, please move me out to tracer client
-//pub mod target_pipeline;
 pub mod target_process;
 pub mod types;
 pub mod utils;
+
+//pub mod target_pipeline;

--- a/src/tracer/src/process_identification/mod.rs
+++ b/src/tracer/src/process_identification/mod.rs
@@ -1,7 +1,7 @@
 pub mod constants;
 pub mod debug_log;
 pub mod recorder; // todo: this is very ugly, please move me out to tracer client
-pub mod target_pipeline;
+//pub mod target_pipeline;
 pub mod target_process;
 pub mod types;
 pub mod utils;

--- a/src/tracer/src/process_identification/mod.rs
+++ b/src/tracer/src/process_identification/mod.rs
@@ -1,6 +1,7 @@
 pub mod constants;
 pub mod debug_log;
 pub mod recorder; // todo: this is very ugly, please move me out to tracer client
+pub mod target_pipeline;
 pub mod target_process;
 pub mod types;
 pub mod utils;

--- a/src/tracer/src/process_identification/target_pipeline/mod.rs
+++ b/src/tracer/src/process_identification/target_pipeline/mod.rs
@@ -19,4 +19,5 @@
 //! started but not matched. A score is computed for each process set for each step, and if the
 //! score is above a threshold, the step matches. If the pipeline ID is known ahead of time, it
 //! can be used to narrow the set of steps to consider.
+mod pipeline_manager;
 mod parser;

--- a/src/tracer/src/process_identification/target_pipeline/mod.rs
+++ b/src/tracer/src/process_identification/target_pipeline/mod.rs
@@ -1,0 +1,22 @@
+//! This module contains the machinery for identifying pipline steps
+//! from target processes.
+//!
+//! There are three possible execution scenarios to consider:
+//! 1. Processes running within containers
+//! 2. Processes not running in containers
+//!     a. Distributed workflow in which all processes for a task are executed in a single VM
+//!     b. Local workflow in which all processes run in the same VM
+//!
+//! Linking processes to steps is essentially the same for (1) and (2a); for (2b) we can
+//! potentially link a process to a step name if the process is only used in a single step,
+//! but if the same step is executed multiple times we can't link a particular process to a
+//! particular step instance. There are also hybrid scenarios, e.g. a local workflow that
+//! uses containers only for some steps.
+//!
+//! The linkage between processes -> step is based on step signatures, where a signature is a
+//! set of processes that are expected to be matched (i.e., recognized by a target rule and
+//! actively monitored) and an optional set of additional processes
+//! started but not matched. A score is computed for each process set for each step, and if the
+//! score is above a threshold, the step matches. If the pipeline ID is known ahead of time, it
+//! can be used to narrow the set of steps to consider.
+mod parser;

--- a/src/tracer/src/process_identification/target_pipeline/parser/mod.rs
+++ b/src/tracer/src/process_identification/target_pipeline/parser/mod.rs
@@ -1,0 +1,2 @@
+pub mod pipeline;
+pub mod yaml_rules_parser;

--- a/src/tracer/src/process_identification/target_pipeline/parser/pipeline.rs
+++ b/src/tracer/src/process_identification/target_pipeline/parser/pipeline.rs
@@ -1,0 +1,64 @@
+#[derive(Debug, Clone)]
+pub struct Pipeline {
+    pub id: String,
+    pub description: Option<String>,
+    pub repo: Option<String>,
+    pub language: Option<String>,
+    pub version: Option<Version>,
+    pub steps: Option<Vec<Step>>,
+    pub optional_steps: Option<Vec<Step>>,
+    pub dependencies: Option<Dependencies>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Version {
+    pub min: Option<String>,
+    pub max: Option<String>,
+    pub exact: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Subworkflow {
+    pub id: String,
+    pub description: Option<String>,
+    pub steps: Option<Vec<Step>>,
+    pub optional_steps: Option<Vec<Step>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Job {
+    pub id: String,
+    pub description: Option<String>,
+    pub rules: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Step {
+    Job(String),
+    OptionalJob(String),
+    Subworkflow(String),
+    OptionalSubworkflow(String),
+    And(Vec<Step>),
+    Or(Vec<Step>),
+}
+
+#[derive(Debug, Clone)]
+pub struct Dependencies {
+    pub subworkflows: Option<Vec<Subworkflow>>,
+    pub jobs: Option<Vec<Job>>,
+    pub parent: Option<Box<&'static Dependencies>>,
+}
+
+impl Dependencies {
+    pub fn new(
+        subworkflows: Option<Vec<Subworkflow>>,
+        jobs: Option<Vec<Job>>,
+        parent: Option<&'static Dependencies>,
+    ) -> Self {
+        Self {
+            subworkflows,
+            jobs,
+            parent: parent.map(Box::new),
+        }
+    }
+}

--- a/src/tracer/src/process_identification/target_pipeline/parser/yaml_rules_parser.rs
+++ b/src/tracer/src/process_identification/target_pipeline/parser/yaml_rules_parser.rs
@@ -1,0 +1,181 @@
+use super::pipeline::{Dependencies, Job, Pipeline, Step, Subworkflow, Version};
+use crate::utils::yaml::{self, Yaml, YamlExt};
+use anyhow::{anyhow, bail, Result};
+use once_cell::sync::Lazy;
+use std::path::Path;
+
+static GLOBAL_DEPENDENCIES: Lazy<Option<Dependencies>> = Lazy::new(|| None);
+
+pub fn load_yaml_pipelines<P: AsRef<Path>>(path: P) -> Result<Vec<Pipeline>> {
+    yaml::load_from_yaml_array_file(path, "pipelines")
+}
+
+pub fn load_yaml_pipelines_from_str(yaml_str: &str) -> Result<Vec<Pipeline>> {
+    yaml::load_from_yaml_array_file(yaml_str, "pipelines")
+}
+
+impl TryFrom<Yaml> for Pipeline {
+    type Error = anyhow::Error;
+
+    fn try_from(yaml: Yaml) -> Result<Self> {
+        let id = yaml.required_string("id")?;
+        let description = yaml.optional_string("description")?;
+        let repo = yaml.optional_string("repo")?;
+        let language = yaml.optional_string("language")?;
+        let version = yaml.optional("version").map(|v| v.try_into()).transpose()?;
+        let subworkflows = yaml
+            .optional_vec("subworkflows")?
+            .map(|v| {
+                v.iter()
+                    .map(|subworkflow| subworkflow.try_into())
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?;
+        let jobs = yaml
+            .optional_vec("jobs")?
+            .map(|v| {
+                v.iter()
+                    .map(|job| job.try_into())
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?;
+        let dependencies = if subworkflows.is_none() && jobs.is_none() {
+            GLOBAL_DEPENDENCIES
+                .as_ref()
+                .map(|dependencies| dependencies.clone())
+        } else {
+            Some(Dependencies::new(
+                subworkflows,
+                jobs,
+                GLOBAL_DEPENDENCIES.as_ref(),
+            ))
+        };
+        let steps = yaml
+            .optional_vec("steps")?
+            .map(|v| {
+                v.iter()
+                    .map(|step| step.try_into())
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?;
+        let optional_steps = yaml
+            .optional_vec("optional_steps")?
+            .map(|v| {
+                v.iter()
+                    .map(|step| step.try_into())
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?;
+        Ok(Pipeline {
+            id,
+            description,
+            repo,
+            language,
+            version,
+            steps,
+            optional_steps,
+            dependencies,
+        })
+    }
+}
+
+impl TryFrom<&Yaml> for Version {
+    type Error = anyhow::Error;
+
+    fn try_from(yaml: &Yaml) -> Result<Self> {
+        let min = yaml.optional_string("min")?;
+        let max = yaml.optional_string("max")?;
+        let exact = yaml.optional_string("exact")?;
+        Ok(Version { min, max, exact })
+    }
+}
+
+impl TryFrom<&Yaml> for Subworkflow {
+    type Error = anyhow::Error;
+
+    fn try_from(yaml: &Yaml) -> Result<Self> {
+        let id = yaml.required_string("id")?;
+        let description = yaml.optional_string("description")?;
+        let steps = yaml
+            .optional_vec("steps")?
+            .map(|v| {
+                v.iter()
+                    .map(|step| step.try_into())
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?;
+        let optional_steps = yaml
+            .optional_vec("optional_steps")?
+            .map(|v| {
+                v.iter()
+                    .map(|step| step.try_into())
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?;
+        Ok(Subworkflow {
+            id,
+            description,
+            steps,
+            optional_steps,
+        })
+    }
+}
+
+impl TryFrom<&Yaml> for Job {
+    type Error = anyhow::Error;
+
+    fn try_from(yaml: &Yaml) -> Result<Self> {
+        let id = yaml.required_string("id")?;
+        let description = yaml.optional_string("description")?;
+        let rules = yaml
+            .required_vec("rules")?
+            .iter()
+            .map(|rule| {
+                rule.as_str()
+                    .ok_or(anyhow!("rule is not a string"))
+                    .map(|s| s.to_string())
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Job {
+            id,
+            description,
+            rules,
+        })
+    }
+}
+
+impl TryFrom<&Yaml> for Step {
+    type Error = anyhow::Error;
+
+    fn try_from(yaml: &Yaml) -> Result<Self> {
+        const STEP_TYPES: &[&str] = &["job", "optional_job", "subworkflow", "optional_subworkflow"];
+        for step_type in STEP_TYPES {
+            if let Some(id) = yaml.optional_string(step_type)? {
+                return match *step_type {
+                    "job" => Ok(Step::Job(id)),
+                    "optional_job" => Ok(Step::OptionalJob(id)),
+                    "subworkflow" => Ok(Step::Subworkflow(id)),
+                    "optional_subworkflow" => Ok(Step::OptionalSubworkflow(id)),
+                    _ => bail!("Unknown step type: {:?}", yaml),
+                };
+            }
+        }
+
+        const COND_TYPES: &[&str] = &["and", "or"];
+        for cond_type in COND_TYPES {
+            if let Some(conditions) = yaml.optional_vec(cond_type)? {
+                let steps = conditions
+                    .iter()
+                    .map(|condition| condition.try_into())
+                    .collect::<Result<Vec<_>>>()?;
+                return match *cond_type {
+                    "and" => Ok(Step::And(steps)),
+                    "or" => Ok(Step::Or(steps)),
+                    _ => bail!("Unknown condition type: {:?}", cond_type),
+                };
+            }
+        }
+
+        bail!("Invalid step: {:?}", yaml);
+    }
+}

--- a/src/tracer/src/process_identification/target_pipeline/pipeline_manager.rs
+++ b/src/tracer/src/process_identification/target_pipeline/pipeline_manager.rs
@@ -138,6 +138,7 @@ impl TargetPipelineManager {
     }
 }
 
+/// A bi-directional many-to-many mapping between jobs and PIDs.
 #[derive(MultiIndexMap, Debug)]
 struct JobPid {
     #[multi_index(hashed_non_unique)]

--- a/src/tracer/src/process_identification/target_pipeline/pipeline_manager.rs
+++ b/src/tracer/src/process_identification/target_pipeline/pipeline_manager.rs
@@ -1,0 +1,207 @@
+use crate::process_identification::target_pipeline::parser::pipeline::{
+    Dependencies, Job, Pipeline, Step,
+};
+use crate::process_identification::target_pipeline::parser::yaml_rules_parser::load_yaml_pipelines;
+use crate::process_identification::target_process::target::Target;
+use multi_index_map::MultiIndexMap;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use tracer_ebpf::ebpf_trigger::ProcessStartTrigger;
+use tracing::trace;
+
+pub const JOB_SCORE_THRESHOLD: f64 = 0.9;
+
+/// A job that is matched to a set of processes that have been started.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JobMatch {
+    /// The ID of the job that was matched.
+    pub id: String,
+    /// The description of the job that was matched.
+    pub description: Option<String>,
+    /// The PIDs that have been matched to this job.
+    pub pids: Vec<usize>,
+    /// The score of the job that was matched.
+    pub score: f64,
+}
+
+pub struct TargetPipelineManager {
+    pipelines: Vec<Pipeline>,
+    jobs: Jobs,
+    job_pids: MultiIndexJobPidMap,
+    pid_to_process: HashMap<usize, ProcessRule>,
+}
+
+impl TargetPipelineManager {
+    fn new<P: AsRef<Path>>(
+        embedded_yaml: Option<&str>,
+        fallback_paths: &[P],
+        targets: &Vec<Target>,
+    ) -> Self {
+        let pipelines = load_yaml_pipelines(embedded_yaml, fallback_paths);
+        let mut jobs = Jobs::default();
+        pipelines.iter().for_each(|pipeline| {
+            let dependencies = &pipeline.dependencies;
+            if let Some(steps) = &pipeline.steps {
+                jobs.add_steps(steps, dependencies, false);
+            }
+            if let Some(steps) = &pipeline.optional_steps {
+                jobs.add_steps(steps, dependencies, true);
+            }
+        });
+        Self {
+            pipelines,
+            jobs,
+            job_pids: MultiIndexJobPidMap::default(),
+            pid_to_process: HashMap::new(),
+        }
+    }
+
+    pub fn register_process(
+        &mut self,
+        process: &ProcessStartTrigger,
+        matched_target: Option<&Target>,
+    ) -> Option<JobMatch> {
+        // TODO: this can lead to false-negatives if PIDs are reused.
+        if self.pid_to_process.contains_key(&process.pid) {
+            trace!("PID {} is already registered", process.pid);
+            return None;
+        }
+
+        let (rule, matched) = if let Some(matched) = matched_target {
+            (&matched.display_name, true)
+        } else {
+            (&process.comm, false)
+        };
+
+        if let Some(jobs) = self.jobs.get_jobs_with(rule) {
+            // add the PID to the set we're tracking
+            self.pid_to_process.insert(
+                process.pid,
+                ProcessRule {
+                    name: rule.clone(),
+                    matched,
+                },
+            );
+            // find any jobs that exceed the score threshold after adding the rule
+            let mut matched_jobs = jobs
+                .iter()
+                .filter_map(|job| {
+                    // TODO: should we check that the rule associated with the PID is not one
+                    // that has already been recognized? Sometimes, the same command will be run
+                    // multiple times in the same job. We could require a separate rule entry in
+                    // the job definition for each time the command is run, or have a way to
+                    // specify the cardinality of the rule within the job.
+
+                    // add the PID to the list for candidate job
+                    self.job_pids.insert(JobPid {
+                        job_id: job.id.clone(),
+                        pid: process.pid,
+                    });
+                    let job_pids = self.job_pids.get_by_job_id(&job.id);
+                    // For now score is just the fraction of rules that have been observed.
+                    // TODO: weight score based on whether the rule is optional or not.
+                    let score = job.rules.len() as f64 / job_pids.len() as f64;
+                    if score > JOB_SCORE_THRESHOLD {
+                        let pids: Vec<usize> = job_pids.iter().map(|job_pid| job_pid.pid).collect();
+                        Some((job, pids, score))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            if matched_jobs.is_empty() {
+                return None;
+            }
+            // if there are multiple matches, pick the one with the highest score
+            if matched_jobs.len() > 1 {
+                matched_jobs.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
+            }
+            let (best_match, pids, score) = matched_jobs.pop().unwrap();
+            if score >= 1.0 {
+                // If the match is perfect (i.e. all rules have been matched to processes) then:
+                // 1) remove the job so we don't update/match it again
+                self.job_pids.remove_by_job_id(&best_match.id);
+                // 2) remove the PIDs associated with the best match from any other candidate jobs
+                for pid in pids.iter() {
+                    self.job_pids.remove_by_pid(pid);
+                }
+            }
+            return Some(JobMatch {
+                id: best_match.id.clone(),
+                description: best_match.description.clone(),
+                pids,
+                score,
+            });
+        }
+
+        None
+    }
+}
+
+#[derive(MultiIndexMap, Debug)]
+struct JobPid {
+    #[multi_index(hashed_non_unique)]
+    job_id: String,
+    #[multi_index(hashed_non_unique)]
+    pid: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ProcessRule {
+    name: String,
+    matched: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct Jobs {
+    jobs: HashMap<String, Job>,
+    rule_to_job: HashMap<String, HashSet<String>>,
+}
+
+impl Jobs {
+    fn add_steps(&mut self, steps: &Vec<Step>, dependencies: &Dependencies, optional: bool) {
+        for step in steps {
+            match step {
+                Step::Job(id) => self.add_job(id, dependencies, optional),
+                Step::OptionalJob(id) => self.add_job(id, dependencies, true),
+                Step::Subworkflow(id) => self.add_subworkflow(id, dependencies, optional),
+                Step::OptionalSubworkflow(id) => self.add_subworkflow(id, dependencies, true),
+                Step::And(steps) => self.add_steps(steps, dependencies, optional),
+                Step::Or(steps) => self.add_steps(steps, dependencies, optional),
+            }
+        }
+    }
+
+    fn add_job(&mut self, id: &String, dependencies: &Dependencies, _optional: bool) {
+        if let Some(job) = dependencies.get_job(id) {
+            if !self.jobs.contains_key(id) {
+                self.jobs.insert(id.clone(), job.clone());
+            }
+            for rule in &job.rules {
+                if let Some(jobs) = self.rule_to_job.get_mut(rule) {
+                    jobs.insert(job.id.clone());
+                } else {
+                    self.rule_to_job
+                        .insert(rule.clone(), HashSet::from([job.id.clone()]));
+                }
+            }
+        }
+    }
+
+    fn add_subworkflow(&mut self, id: &String, dependencies: &Dependencies, optional: bool) {
+        if let Some(subworkflow) = dependencies.get_subworkflow(id) {
+            if let Some(steps) = &subworkflow.steps {
+                self.add_steps(steps, dependencies, optional);
+            }
+            if let Some(steps) = &subworkflow.optional_steps {
+                self.add_steps(steps, dependencies, true);
+            }
+        }
+    }
+
+    fn get_jobs_with(&self, rule: &str) -> Option<HashSet<&Job>> {
+        self.rule_to_job
+            .get(rule)
+            .map(|jobs| jobs.iter().map(|job| self.jobs.get(job).unwrap()).collect())
+    }
+}

--- a/src/tracer/src/process_identification/target_pipeline/yml_rules/tracer.modules.yml
+++ b/src/tracer/src/process_identification/target_pipeline/yml_rules/tracer.modules.yml
@@ -1,0 +1,1 @@
+modules:

--- a/src/tracer/src/process_identification/target_pipeline/yml_rules/tracer.pipelines.yml
+++ b/src/tracer/src/process_identification/target_pipeline/yml_rules/tracer.pipelines.yml
@@ -1,0 +1,31 @@
+pipelines:
+  - id: nf-core/rnaseq
+    description: RNA sequencing analysis pipeline for gene/isoform quantification and extensive quality control.
+    repo: https://github.com/nf-core/rnaseq
+    language: nextflow
+    version:
+      min: 3.19.0
+    subworkflows:
+      - id: PREPARE_GENOME
+        description: Create genome indexes for RNA-seq analysis.
+        steps:
+          - or:
+              - job: GUNZIP_GTF
+              - and:
+                  - optional_job: GUNZIP_GFF
+                  - job: GFFREAD
+    jobs:
+      - id: GUNZIP_GTF
+        description: Unzip the GTF file.
+        rules:
+          - gunzip_gtf
+      - id: GUNZIP_GFF
+        description: Unzip the GFF file.
+        rules:
+          - gunzip_gff
+      - id: GFFREAD
+        description: Read the GFF file.
+        rules:
+          - gffread
+    steps:
+      - subworkflow: PREPARE_GENOME

--- a/src/tracer/src/process_identification/target_process/parser/conditions.rs
+++ b/src/tracer/src/process_identification/target_process/parser/conditions.rs
@@ -8,15 +8,15 @@ pub enum Condition {
 }
 #[derive(Clone, Debug)]
 pub enum SimpleCondition {
-    ProcessNameIs { process_name_is: String },
-    ProcessNameContains { process_name_contains: String },
-    MinArgs { min_args: usize },
-    ArgsNotContain { args_not_contain: String },
-    FirstArgIs { first_arg_is: String },
-    CommandContains { command_contains: String },
-    CommandNotContains { command_not_contains: String },
-    CommandMatchesRegex { command_matches_regex: String },
-    SubcommandIsOneOf { subcommands: Vec<String> },
+    ProcessNameIs(String),
+    ProcessNameContains(String),
+    MinArgs(usize),
+    ArgsNotContain(String),
+    FirstArgIs(String),
+    CommandContains(String),
+    CommandNotContains(String),
+    CommandMatchesRegex(String),
+    SubcommandIsOneOf(Vec<String>),
 }
 
 #[derive(Clone, Debug)]
@@ -34,33 +34,31 @@ impl CompoundCondition {
 impl Condition {
     pub fn into_match_type(self) -> MatchType {
         match self {
-            Condition::Simple(SimpleCondition::ProcessNameIs { process_name_is }) => {
+            Condition::Simple(SimpleCondition::ProcessNameIs(process_name_is)) => {
                 MatchType::ProcessNameIs(process_name_is.clone())
             }
-            Condition::Simple(SimpleCondition::ProcessNameContains {
-                process_name_contains,
-            }) => MatchType::ProcessNameContains(process_name_contains.clone()),
-            Condition::Simple(SimpleCondition::MinArgs { min_args }) => {
-                MatchType::MinArgs(min_args)
+            Condition::Simple(SimpleCondition::ProcessNameContains(process_name_contains)) => {
+                MatchType::ProcessNameContains(process_name_contains.clone())
             }
-            Condition::Simple(SimpleCondition::ArgsNotContain { args_not_contain }) => {
+            Condition::Simple(SimpleCondition::MinArgs(min_args)) => MatchType::MinArgs(min_args),
+            Condition::Simple(SimpleCondition::ArgsNotContain(args_not_contain)) => {
                 MatchType::ArgsNotContain(args_not_contain.clone())
             }
-            Condition::Simple(SimpleCondition::FirstArgIs { first_arg_is }) => {
+            Condition::Simple(SimpleCondition::FirstArgIs(first_arg_is)) => {
                 MatchType::FirstArgIs(first_arg_is.clone())
             }
-            Condition::Simple(SimpleCondition::CommandContains { command_contains }) => {
+            Condition::Simple(SimpleCondition::CommandContains(command_contains)) => {
                 MatchType::CommandContains(command_contains.clone())
             }
-            Condition::Simple(SimpleCondition::CommandNotContains {
-                command_not_contains,
-            }) => MatchType::CommandNotContains(command_not_contains.clone()),
-            Condition::Simple(SimpleCondition::CommandMatchesRegex {
-                command_matches_regex,
-            }) => MatchType::CommandMatchesRegex(command_matches_regex.clone()),
+            Condition::Simple(SimpleCondition::CommandNotContains(command_not_contains)) => {
+                MatchType::CommandNotContains(command_not_contains.clone())
+            }
+            Condition::Simple(SimpleCondition::CommandMatchesRegex(command_matches_regex)) => {
+                MatchType::CommandMatchesRegex(command_matches_regex.clone())
+            }
             Condition::And(and_condition) => MatchType::And(and_condition.into_match_types()),
             Condition::Or(or_condition) => MatchType::Or(or_condition.into_match_types()),
-            Condition::Simple(SimpleCondition::SubcommandIsOneOf { subcommands }) => {
+            Condition::Simple(SimpleCondition::SubcommandIsOneOf(subcommands)) => {
                 MatchType::SubcommandIsOneOf(subcommands.clone())
             }
         }

--- a/src/tracer/src/process_identification/target_process/parser/yaml_rules_parser.rs
+++ b/src/tracer/src/process_identification/target_process/parser/yaml_rules_parser.rs
@@ -2,27 +2,21 @@ use crate::process_identification::target_process::parser::conditions::{
     CompoundCondition, Condition, SimpleCondition,
 };
 use crate::process_identification::target_process::parser::rule::Rule;
-use crate::process_identification::target_process::target::Target;
-use crate::utils::yaml::{self, Yaml, YamlExt};
+use crate::utils::yaml::{Yaml, YamlExt, YamlVecLoader};
 use anyhow::{anyhow, bail, Result};
 use std::path::Path;
 
-pub fn load_yaml_rules<P: AsRef<Path>>(path: P) -> Result<Vec<Target>> {
-    let rules: Vec<Rule> = yaml::load_from_yaml_array_file(path, "rules")?;
-    let targets: Vec<Target> = rules
-        .into_iter()
-        .map(|rule| rule.clone().into_target())
-        .collect();
-    Ok(targets)
-}
-
-pub fn load_yaml_rules_from_str(yaml_str: &str) -> Result<Vec<Target>> {
-    let rules: Vec<Rule> = yaml::load_from_yaml_array_str(yaml_str, "rules")?;
-    let targets: Vec<Target> = rules
-        .into_iter()
-        .map(|rule| rule.clone().into_target())
-        .collect();
-    Ok(targets)
+pub fn load_yaml_rules<P: AsRef<Path>>(
+    embedded_yaml: Option<&str>,
+    fallback_paths: &[P],
+) -> Vec<Rule> {
+    YamlVecLoader {
+        module: "TargetManager",
+        key: "rules",
+        embedded_yaml,
+        fallback_paths,
+    }
+    .load()
 }
 
 impl TryFrom<Yaml> for Rule {

--- a/src/tracer/src/process_identification/target_process/parser/yaml_rules_parser.rs
+++ b/src/tracer/src/process_identification/target_process/parser/yaml_rules_parser.rs
@@ -3,122 +3,115 @@ use crate::process_identification::target_process::parser::conditions::{
 };
 use crate::process_identification::target_process::parser::rule::Rule;
 use crate::process_identification::target_process::target::Target;
-use std::fs;
+use crate::utils::yaml::{self, Yaml, YamlExt};
+use anyhow::{anyhow, bail, Result};
 use std::path::Path;
-use yaml_rust2::{Yaml, YamlLoader};
 
-pub fn load_yaml_rules<P: AsRef<Path>>(path: P) -> Result<Vec<Target>, Box<dyn std::error::Error>> {
-    let path_ref = path.as_ref();
-    let yaml_content = fs::read_to_string(path_ref)?;
-    load_yaml_rules_from_str(&yaml_content)
-}
-
-pub fn load_yaml_rules_from_str(
-    yaml_content: &str,
-) -> Result<Vec<Target>, Box<dyn std::error::Error>> {
-    let docs = YamlLoader::load_from_str(yaml_content)?;
-    let doc = &docs[0];
-
-    let rules_yaml = &doc["rules"];
-    let rules_vec = rules_yaml
-        .as_vec()
-        .ok_or("Expected 'rules' to be an array")?;
-
-    let rules: Result<Vec<Rule>, _> = rules_vec.iter().map(parse_rule).collect();
-
-    let targets: Vec<Target> = rules?
+pub fn load_yaml_rules<P: AsRef<Path>>(path: P) -> Result<Vec<Target>> {
+    let rules: Vec<Rule> = yaml::load_from_yaml_array_file(path, "rules")?;
+    let targets: Vec<Target> = rules
         .into_iter()
         .map(|rule| rule.clone().into_target())
         .collect();
     Ok(targets)
 }
 
-fn parse_rule(yaml: &Yaml) -> Result<Rule, Box<dyn std::error::Error>> {
-    let display_name = yaml["display_name"]
-        .as_str()
-        .ok_or("display_name not found or not a string")?
-        .to_string();
-    let condition = parse_condition(&yaml["condition"])?;
-
-    Ok(Rule {
-        display_name,
-        condition,
-    })
+pub fn load_yaml_rules_from_str(yaml_str: &str) -> Result<Vec<Target>> {
+    let rules: Vec<Rule> = yaml::load_from_yaml_array_str(yaml_str, "rules")?;
+    let targets: Vec<Target> = rules
+        .into_iter()
+        .map(|rule| rule.clone().into_target())
+        .collect();
+    Ok(targets)
 }
 
-fn parse_condition(yaml: &Yaml) -> Result<Condition, Box<dyn std::error::Error>> {
-    if let Some(and_conds) = yaml["and"].as_vec() {
-        let conditions = and_conds
-            .iter()
-            .map(parse_condition)
-            .collect::<Result<Vec<_>, _>>()?;
-        return Ok(Condition::And(CompoundCondition(conditions)));
-    }
+impl TryFrom<Yaml> for Rule {
+    type Error = anyhow::Error;
 
-    if let Some(or_conds) = yaml["or"].as_vec() {
-        let conditions = or_conds
-            .iter()
-            .map(parse_condition)
-            .collect::<Result<Vec<_>, _>>()?;
-        return Ok(Condition::Or(CompoundCondition(conditions)));
+    fn try_from(yaml: Yaml) -> Result<Self> {
+        let display_name = yaml.required_string("display_name")?;
+        let condition = yaml.required("condition")?.try_into()?;
+        Ok(Rule {
+            display_name,
+            condition,
+        })
     }
+}
 
-    if let Some(val) = yaml["process_name_is"].as_str() {
-        return Ok(Condition::Simple(SimpleCondition::ProcessNameIs {
-            process_name_is: val.to_string(),
-        }));
-    }
+impl TryFrom<&Yaml> for Condition {
+    type Error = anyhow::Error;
 
-    if let Some(val) = yaml["process_name_contains"].as_str() {
-        return Ok(Condition::Simple(SimpleCondition::ProcessNameContains {
-            process_name_contains: val.to_string(),
-        }));
-    }
+    fn try_from(yaml: &Yaml) -> Result<Self> {
+        const SIMPLE_TYPES: &[&str] = &[
+            "process_name_is",
+            "process_name_contains",
+            "min_args",
+            "args_not_contain",
+            "first_arg_is",
+            "command_contains",
+            "command_not_contains",
+            "command_matches_regex",
+            "subcommand_is_one_of",
+        ];
 
-    if let Some(val) = yaml["min_args"].as_i64() {
-        return Ok(Condition::Simple(SimpleCondition::MinArgs {
-            min_args: val as usize,
-        }));
-    }
+        for simple_type in SIMPLE_TYPES {
+            if let Some(val) = yaml.optional(simple_type) {
+                return match *simple_type {
+                    "process_name_is" => Ok(Condition::Simple(SimpleCondition::ProcessNameIs(
+                        val.to_string()?,
+                    ))),
+                    "process_name_contains" => Ok(Condition::Simple(
+                        SimpleCondition::ProcessNameContains(val.to_string()?),
+                    )),
+                    "min_args" => Ok(Condition::Simple(SimpleCondition::MinArgs(val.to_usize()?))),
+                    "args_not_contain" => Ok(Condition::Simple(SimpleCondition::ArgsNotContain(
+                        val.to_string()?,
+                    ))),
+                    "first_arg_is" => Ok(Condition::Simple(SimpleCondition::FirstArgIs(
+                        val.to_string()?,
+                    ))),
+                    "command_contains" => Ok(Condition::Simple(SimpleCondition::CommandContains(
+                        val.to_string()?,
+                    ))),
+                    "command_not_contains" => Ok(Condition::Simple(
+                        SimpleCondition::CommandNotContains(val.to_string()?),
+                    )),
+                    "command_matches_regex" => Ok(Condition::Simple(
+                        SimpleCondition::CommandMatchesRegex(val.to_string()?),
+                    )),
+                    "subcommand_is_one_of" => {
+                        let subcommands = val
+                            .as_vec()
+                            .ok_or(anyhow!("Expected an array"))?
+                            .iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect();
+                        Ok(Condition::Simple(SimpleCondition::SubcommandIsOneOf(
+                            subcommands,
+                        )))
+                    }
+                    _ => bail!("Invalid simple condition type: {}", simple_type),
+                };
+            }
+        }
 
-    if let Some(val) = yaml["args_not_contain"].as_str() {
-        return Ok(Condition::Simple(SimpleCondition::ArgsNotContain {
-            args_not_contain: val.to_string(),
-        }));
-    }
+        const COND_TYPES: &[&str] = &["and", "or"];
+        for cond_type in COND_TYPES {
+            if let Some(conditions_yml) = yaml.optional_vec(cond_type)? {
+                let conditions = CompoundCondition(
+                    conditions_yml
+                        .iter()
+                        .map(|condition| condition.try_into())
+                        .collect::<Result<Vec<_>>>()?,
+                );
+                return match *cond_type {
+                    "and" => Ok(Condition::And(conditions)),
+                    "or" => Ok(Condition::Or(conditions)),
+                    _ => bail!("Unknown condition type: {:?}", cond_type),
+                };
+            }
+        }
 
-    if let Some(val) = yaml["first_arg_is"].as_str() {
-        return Ok(Condition::Simple(SimpleCondition::FirstArgIs {
-            first_arg_is: val.to_string(),
-        }));
+        bail!("Invalid step: {:?}", yaml);
     }
-
-    if let Some(val) = yaml["command_contains"].as_str() {
-        return Ok(Condition::Simple(SimpleCondition::CommandContains {
-            command_contains: val.to_string(),
-        }));
-    }
-    if let Some(val) = yaml["command_not_contains"].as_str() {
-        return Ok(Condition::Simple(SimpleCondition::CommandNotContains {
-            command_not_contains: val.to_string(),
-        }));
-    }
-
-    if let Some(val) = yaml["command_matches_regex"].as_str() {
-        return Ok(Condition::Simple(SimpleCondition::CommandMatchesRegex {
-            command_matches_regex: val.to_string(),
-        }));
-    }
-
-    if let Some(val) = yaml["subcommand_is_one_of"].as_vec() {
-        let subcommands = val
-            .iter()
-            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-            .collect();
-        return Ok(Condition::Simple(SimpleCondition::SubcommandIsOneOf {
-            subcommands,
-        }));
-    }
-
-    Err("Invalid condition".into())
 }

--- a/src/tracer/src/process_identification/target_process/target_match.rs
+++ b/src/tracer/src/process_identification/target_process/target_match.rs
@@ -22,6 +22,7 @@ pub struct ProcessMatch {
     pub is_match: bool,
     pub sub_command: Option<String>,
 }
+
 /// Simple target matching function
 /// It returns (bool, Option<String>), the Option<String> is useful when a subcommand is matched to dinamically update the display name
 pub fn matches_target(target_match: &MatchType, process: &ProcessStartTrigger) -> ProcessMatch {

--- a/src/tracer/src/utils/mod.rs
+++ b/src/tracer/src/utils/mod.rs
@@ -8,3 +8,4 @@ pub mod analytics;
 pub mod cli;
 pub mod file_system;
 pub mod system_info;
+pub mod yaml;

--- a/src/tracer/src/utils/yaml.rs
+++ b/src/tracer/src/utils/yaml.rs
@@ -1,0 +1,115 @@
+use anyhow::{anyhow, bail, Result};
+use std::fs;
+use std::path::Path;
+use yaml_rust2::YamlLoader;
+// re-export Yaml for convenience
+pub use yaml_rust2::Yaml;
+
+pub fn load_from_yaml_array_file<P: AsRef<Path>, T: TryFrom<Yaml, Error = anyhow::Error>>(
+    path: P,
+    key: &'static str,
+) -> Result<Vec<T>> {
+    let yaml_str = fs::read_to_string(path.as_ref())?;
+    load_from_yaml_array_str(&yaml_str, key)
+}
+
+pub fn load_from_yaml_array_str<T: TryFrom<Yaml, Error = anyhow::Error>>(
+    yaml_str: &str,
+    key: &'static str,
+) -> Result<Vec<T>> {
+    let docs = YamlLoader::load_from_str(yaml_str)?;
+    docs.into_iter()
+        .next()
+        .ok_or(anyhow!("Empty yaml file"))?
+        .into_hash()
+        .ok_or(anyhow!("Expected top-level element to be a hash"))?
+        .remove(&Yaml::String(key.into()))
+        .ok_or(anyhow!("Missing top-level key {}", key))?
+        .into_iter()
+        .map(|yaml| yaml.try_into())
+        .collect()
+}
+
+pub trait YamlExt: Sized {
+    fn required(&self, key: &'static str) -> Result<&Yaml>;
+
+    fn optional(&self, key: &'static str) -> Option<&Yaml>;
+
+    fn required_string(&self, key: &'static str) -> Result<String>;
+
+    fn optional_string(&self, key: &'static str) -> Result<Option<String>>;
+
+    fn required_vec(&self, key: &'static str) -> Result<&Vec<Self>>;
+
+    fn optional_vec(&self, key: &'static str) -> Result<Option<&Vec<Self>>>;
+
+    fn to_string(&self) -> Result<String>;
+
+    fn to_usize(&self) -> Result<usize>;
+}
+
+impl YamlExt for Yaml {
+    fn required(&self, key: &'static str) -> Result<&Yaml> {
+        let value = &self[key];
+        if value.is_badvalue() {
+            bail!("Missing key {}", key)
+        } else {
+            Ok(value)
+        }
+    }
+
+    fn optional(&self, key: &'static str) -> Option<&Yaml> {
+        let value = &self[key];
+        if value.is_badvalue() {
+            None
+        } else {
+            Some(value)
+        }
+    }
+
+    fn required_string(&self, key: &'static str) -> Result<String> {
+        match &self[key] {
+            Yaml::String(s) => Ok(s.clone()),
+            Yaml::BadValue => bail!("Missing key {}", key),
+            _ => bail!("Expected {} to be a string", key),
+        }
+    }
+
+    fn optional_string(&self, key: &'static str) -> Result<Option<String>> {
+        match &self[key] {
+            Yaml::String(s) => Ok(Some(s.clone())),
+            Yaml::BadValue => Ok(None),
+            _ => bail!("Expected {} to be a string", key),
+        }
+    }
+
+    fn required_vec(&self, key: &'static str) -> Result<&Vec<Self>> {
+        match &self[key] {
+            Yaml::Array(v) => Ok(v),
+            Yaml::BadValue => bail!("Missing key {}", key),
+            _ => bail!("Expected {} to be an array", key),
+        }
+    }
+
+    fn optional_vec(&self, key: &'static str) -> Result<Option<&Vec<Self>>> {
+        match &self[key] {
+            Yaml::Array(v) => Ok(Some(v)),
+            Yaml::BadValue => Ok(None),
+            _ => bail!("Expected {} to be an array", key),
+        }
+    }
+
+    fn to_string(&self) -> Result<String> {
+        match self {
+            Yaml::String(s) => Ok(s.clone()),
+            _ => bail!("Expected a string"),
+        }
+    }
+
+    fn to_usize(&self) -> Result<usize> {
+        match self {
+            Yaml::Integer(i) => Ok(*i as usize),
+            _ => bail!("Expected a number"),
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary

This PR implements a `PipelineManager` (similar to `TargetManager`) which is based on rules defined in a YAML file. For each process start, the `PipelineManager` tries to match the process to jobs, which are collections of targets and map to e.g. nextflow `Process`es. For each matched job, it computes the match score and returns the best matching job for any jobs above a threshold score. This match information could then be used by the UI to group processes into pipeline steps, which are a more natural grouping for the user.

Currently, the score is just computed as the fraction of rules that can be associated to a recognized process.

Currently, this is only useful for the cases where all the processes running on the local machine are associated with a single pipeline step (e.g. running inside a container, or a distributed workflow where each pipeline step runs on a different VM). If all workflow processes run in the same VM, the manager will likely be unable to match them correctly to jobs.

## 🔍 Related Issues/Tickets
ENG-429

## ✨ Changes Introduced
* Define yaml format for pipeline-level rules
* Create parser for pipeline yaml format
* Create utils module with common code for YAML parsing
* Refactor `target_process::parser` to use common YAML parsing code
* Implement `PipelineManager`

## ✨ Infrastructure Impact
None yet - eventually the Pipeline manager will need to be wired up and called within async code for each process start.


## ✅ Checklist
- [x] Code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have tested the changes and they work as expected
- [ ] Documentation has been updated if needed
- [ ] Tests have been added or updated

## 🛠️ How to Test
<!-- Provide instructions on how to test your changes -->

## 🚀 Screenshots (if applicable)
<!-- Add screenshots or GIFs to demonstrate the changes -->

## 📌 Additional Notes
<!-- Add any other relevant information -->
