### PR TITLE
bugfix/quick refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4934,7 +4934,6 @@ dependencies = [
  "log",
  "mockall",
  "octocrab",
- "once_cell",
  "percent-encoding",
  "pretty_assertions_sorted",
  "rand 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,7 +4931,6 @@ dependencies = [
  "ec2_instance_metadata",
  "futures-util",
  "itertools 0.14.0",
- "lazy_static",
  "log",
  "mockall",
  "octocrab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,5 @@ yaml-rust2 = "0.10.3"
 pretty_assertions_sorted = "1.2.3"
 bollard = "0.19.0"
 built = { version = "0.8.0", features = ["chrono", "git2"] }
-lazy_static = "1.5.0"
 multi_index_map = "0.15.0"
 tokio-retry = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ uuid = { version = "1.17.0", features = [
     "fast-rng",
     "macro-diagnostics",
 ] }
-once_cell = "1.21.3"
+
 
 aws-config = { version = "1.6.3", features = ["behavior-version-latest"] }
 aws-sdk-pricing = "1.74.0"

--- a/src/tracer/Cargo.toml
+++ b/src/tracer/Cargo.toml
@@ -29,7 +29,7 @@ chrono = { workspace = true }
 sysinfo = { workspace = true }
 tracer_ebpf = { path = "../ebpf" }
 itertools = { workspace = true }
-once_cell = { workspace = true }
+
 mockall = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true }

--- a/src/tracer/Cargo.toml
+++ b/src/tracer/Cargo.toml
@@ -54,7 +54,6 @@ dialoguer = { workspace = true }
 regex = { workspace = true }
 rustls = { workspace = true }
 yaml-rust2 = { workspace = true }
-lazy_static = { workspace = true }
 shlex = { workspace = true }
 bollard = { workspace = true }
 futures-util = { workspace = true }

--- a/src/tracer/src/client/events/run_details.rs
+++ b/src/tracer/src/client/events/run_details.rs
@@ -1,10 +1,10 @@
-use once_cell::sync::Lazy;
 use rand::seq::IndexedRandom;
 use rand::Rng;
+use std::sync::LazyLock;
 
-static ADJECTIVES: Lazy<Vec<&str>> =
-    Lazy::new(|| vec!["snowy", "silent", "desert", "mystic", "ancient"]);
-static ANIMALS: Lazy<Vec<&str>> = Lazy::new(|| {
+static ADJECTIVES: LazyLock<Vec<&str>> =
+    LazyLock::new(|| vec!["snowy", "silent", "desert", "mystic", "ancient"]);
+static ANIMALS: LazyLock<Vec<&str>> = LazyLock::new(|| {
     vec![
         "owl", "wolf", "lion", "tiger", "hawk", "eagle", "fox", "bear", "penguin", "dolphin",
         "elephant", "leopard", "giraffe", "rhino", "panther", "falcon", "lynx", "moose", "otter",

--- a/src/tracer/src/daemon/routes.rs
+++ b/src/tracer/src/daemon/routes.rs
@@ -8,17 +8,18 @@ use crate::daemon::handlers::tag::{tag, TAG_ENDPOINT};
 use crate::daemon::handlers::terminate::{terminate, TERMINATE_ENDPOINT};
 use crate::daemon::state::DaemonState;
 use axum::routing::{get, post, MethodRouter};
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
-lazy_static! {
-    pub(super) static ref ROUTES: Vec<(&'static str, MethodRouter<DaemonState>)> = vec![
-        (LOG_ENDPOINT, post(log)),
-        (TERMINATE_ENDPOINT, post(terminate)),
-        (START_ENDPOINT, post(start)),
-        (END_ENDPOINT, post(end)),
-        (ALERT_ENDPOINT, post(alert)),
-        (REFRESH_CONFIG_ENDPOINT, post(refresh_config)),
-        (TAG_ENDPOINT, post(tag)),
-        (INFO_ENDPOINT, get(info)),
-    ];
-}
+pub(super) static ROUTES: LazyLock<Vec<(&'static str, MethodRouter<DaemonState>)>> =
+    LazyLock::new(|| {
+        vec![
+            (LOG_ENDPOINT, post(log)),
+            (TERMINATE_ENDPOINT, post(terminate)),
+            (START_ENDPOINT, post(start)),
+            (END_ENDPOINT, post(end)),
+            (ALERT_ENDPOINT, post(alert)),
+            (REFRESH_CONFIG_ENDPOINT, post(refresh_config)),
+            (TAG_ENDPOINT, post(tag)),
+            (INFO_ENDPOINT, get(info)),
+        ]
+    });

--- a/src/tracer/src/extracts/data_samples.rs
+++ b/src/tracer/src/extracts/data_samples.rs
@@ -1,5 +1,3 @@
-//use once_cell::sync::Lazy;
-
 // Have this as a seperate Vec because the assumption is the datasamples because it's faster to go
 // through a dedicated list than filtering the main target_list to find all CommandContainsV2
 // variants

--- a/src/tracer/src/utils/info_display.rs
+++ b/src/tracer/src/utils/info_display.rs
@@ -38,8 +38,7 @@ impl InfoDisplay {
                 "name": &inner.pipeline_name,
                 "type": inner.tags.pipeline_type.as_deref().unwrap_or("Not set"),
                 "environment": inner.tags.environment.as_deref().unwrap_or("Not set"),
-                "user": inner.tags.user_operator.as_deref().unwrap_or("Not set"),
-                "dashboard_url": inner.get_pipeline_url(),
+                "user": inner.tags.user_operator.as_deref().unwrap_or("Not set")
             });
             json["run"] = serde_json::json!({
                 "name": &inner.run_name,
@@ -103,7 +102,6 @@ impl InfoDisplay {
         formatter.add_field("Pipeline type", pipeline_type, "white");
         formatter.add_field("Environment", pipeline_environment, "yellow");
         formatter.add_field("User", pipeline_user, "magenta");
-        formatter.add_hyperlink("Open dashboard ↗️", "Dashboard", &inner.get_pipeline_url());
 
         formatter.add_empty_line();
         formatter.add_section_header("Run details");

--- a/src/tracer/src/utils/version.rs
+++ b/src/tracer/src/utils/version.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::cmp::Ordering;
 use std::fmt;
+use std::sync::LazyLock;
 
 include!(concat!(env!("OUT_DIR"), "/built.rs"));
 
@@ -26,8 +26,8 @@ impl Version {
     }
 
     pub fn current() -> &'static Self {
-        static VERSION: Lazy<Version> =
-            Lazy::new(|| Version::from_str(Version::current_str()).unwrap());
+        static VERSION: LazyLock<Version> =
+            LazyLock::new(|| Version::from_str(Version::current_str()).unwrap());
         &VERSION
     }
 
@@ -39,8 +39,8 @@ impl Version {
     /// Returns an error if the string is not in the correct format
     /// or any part is not a valid number.
     pub(super) fn from_str(s: &str) -> Result<Self, String> {
-        static RE: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r"^(\d+)\.(\d+)\.(\d+)(?:\+(\d+))?$").unwrap());
+        static RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(\d+)\.(\d+)\.(\d+)(?:\+(\d+))?$").unwrap());
 
         let err_msg = format!("Failed to parse version string: {}", s);
         let caps = RE.captures(s).ok_or(err_msg.clone())?;


### PR DESCRIPTION
## 📌 Summary
<!-- Provide a concise summary of your changes -->
Refactoring current code based on changes requested by @jdidion & @davincios 
![image](https://github.com/user-attachments/assets/f2512db7-7d7d-4548-8785-ca1d3b415e1e)

## ✨ Changes Introduced
<!-- Briefly describe the changes in this PR -->
Removed the dashboard link for pipelines shown by `tracer info`. Only showing run dashboard link now
Removed all references to once_cell and replaced with std::sync::LazyLock to remove dependency.
Replaced EBPFWatcher makeshift boolean check (using OnceCell) to Arc<Mutex<bool>>
Fixed boxformatter to fallback when using macos terminal or github actions