### PR TITLE
Remove Links

### DIFF
--- a/src/tracer/src/nondaemon_commands.rs
+++ b/src/tracer/src/nondaemon_commands.rs
@@ -60,15 +60,16 @@ pub async fn wait(api_client: &DaemonClient) -> Result<()> {
     bail!("Daemon not started yet")
 }
 pub async fn print_info(api_client: &DaemonClient, json: bool) -> Result<()> {
-    let mut display = InfoDisplay::new(170, json);
     let info = match api_client.send_info_request().await {
         Ok(info) => info,
         Err(e) => {
+            let mut display = InfoDisplay::new(80, json);
             tracing::error!("Error getting info response: {e}");
             display.print_error();
             return Ok(());
         }
     };
+    let display = InfoDisplay::new(150, json);
     display.print(info);
     Ok(())
 }

--- a/src/tracer/src/nondaemon_commands.rs
+++ b/src/tracer/src/nondaemon_commands.rs
@@ -60,7 +60,7 @@ pub async fn wait(api_client: &DaemonClient) -> Result<()> {
     bail!("Daemon not started yet")
 }
 pub async fn print_info(api_client: &DaemonClient, json: bool) -> Result<()> {
-    let mut display = InfoDisplay::new(70, json);
+    let mut display = InfoDisplay::new(170, json);
     let info = match api_client.send_info_request().await {
         Ok(info) => info,
         Err(e) => {

--- a/src/tracer/src/utils/cli/box_formatter.rs
+++ b/src/tracer/src/utils/cli/box_formatter.rs
@@ -112,7 +112,7 @@ impl BoxFormatter {
         &self.output
     }
     pub fn add_hyperlink(&mut self, label: &str, url: &str) {
-        let link = format!("🔗 {}", url).blue().to_string();
+        let link = format!("{}", url).blue().to_string();
         writeln!(&mut self.output, "│ {:<20} │ {}  ", label, link).unwrap();
     }
 }

--- a/src/tracer/src/utils/cli/box_formatter.rs
+++ b/src/tracer/src/utils/cli/box_formatter.rs
@@ -10,25 +10,15 @@ const STATUS_INFO: Emoji<'_, '_> = Emoji("ℹ️ ", "ℹ️ ");
 pub struct BoxFormatter {
     output: String,
     width: usize,
-    fallback_terminal: bool, //for terminals that cannot output special formatted text
 }
 
 /// Formats a box like interface in the command line.
 /// create with `BoxFormatter::new(width)`
 impl BoxFormatter {
     pub fn new(width: usize) -> Self {
-        // Check if running in Terminal.app
-        let macos_terminal = matches!(
-            std::env::var("TERM_PROGRAM").as_deref(),
-            Ok("Apple_Terminal")
-        );
-        let is_github_actions = std::env::var("GITHUB_ACTIONS").is_ok_and(|v| v == "true");
-        let is_fallback = macos_terminal || is_github_actions;
-        let width = if is_fallback { width + 100 } else { width };
         Self {
             output: String::new(),
             width,
-            fallback_terminal: is_fallback,
         }
     }
 
@@ -121,17 +111,8 @@ impl BoxFormatter {
     pub fn get_output(&self) -> &str {
         &self.output
     }
-    pub fn add_hyperlink(&mut self, label: &str, fallback_label: &str, url: &str) {
-        if self.fallback_terminal {
-            // Terminal.app: show plain blue URL
-            let link = format!("🔗 {}", url).blue().to_string();
-            writeln!(&mut self.output, "│ {:<20} │ {}  ", fallback_label, link).unwrap();
-        } else {
-            // Other terminals: clickable hyperlink
-            let hyperlink = format!("\x1B]8;;{}\x07{}\x1B]8;;\x07", url, label);
-            let link = hyperlink.blue().to_string();
-            let label = "";
-            writeln!(&mut self.output, "│ {:<20} │ {}", label, link).unwrap();
-        };
+    pub fn add_hyperlink(&mut self, label: &str, url: &str) {
+        let link = format!("🔗 {}", url).blue().to_string();
+        writeln!(&mut self.output, "│ {:<20} │ {}  ", label, link).unwrap();
     }
 }

--- a/src/tracer/src/utils/cli/box_formatter.rs
+++ b/src/tracer/src/utils/cli/box_formatter.rs
@@ -112,7 +112,7 @@ impl BoxFormatter {
         &self.output
     }
     pub fn add_hyperlink(&mut self, label: &str, url: &str) {
-        let link = format!("{}", url).blue().to_string();
+        let link = url.blue().to_string();
         writeln!(&mut self.output, "│ {:<20} │ {}  ", label, link).unwrap();
     }
 }

--- a/src/tracer/src/utils/info_display.rs
+++ b/src/tracer/src/utils/info_display.rs
@@ -64,7 +64,7 @@ impl InfoDisplay {
         });
         println!("{}", serde_json::to_string_pretty(&json).unwrap());
     }
-    fn format_status(&self, formatter: &mut BoxFormatter, runtime: &String) {
+    fn format_status(&self, formatter: &mut BoxFormatter, runtime: &String, url: &str) {
         formatter.add_header("Tracer status");
         formatter.add_empty_line();
         formatter.add_status_field(
@@ -73,6 +73,7 @@ impl InfoDisplay {
             "active",
         );
         formatter.add_field("Version", &Version::current().to_string(), "bold");
+        formatter.add_hyperlink("Dashboard", url);
         formatter.add_empty_line();
     }
 
@@ -87,7 +88,7 @@ impl InfoDisplay {
         }
         let inner = info.inner.as_ref().unwrap();
 
-        self.format_status(formatter, &inner.formatted_runtime());
+        self.format_status(formatter, &inner.formatted_runtime(), &inner.get_run_url());
 
         formatter.add_section_header("Pipeline details");
         formatter.add_empty_line();
@@ -120,9 +121,6 @@ impl InfoDisplay {
                 "white",
             );
         }
-
-        formatter.add_hyperlink("Open dashboard ↗️", "Dashboard", &inner.get_run_url());
-
         formatter.add_empty_line();
     }
 
@@ -140,13 +138,8 @@ impl InfoDisplay {
         formatter.add_section_header("Next steps");
         formatter.add_empty_line();
         formatter.add_field("Interactive setup", "tracer init", "cyan");
+        formatter.add_hyperlink("Sandbox", "https://sandbox.tracer.cloud");
         formatter.add_hyperlink(
-            "Visualize data 📈",
-            "Sandbox",
-            "https://sandbox.tracer.cloud",
-        );
-        formatter.add_hyperlink(
-            "Read docs 📄",
             "Documentation",
             "https://github.com/Tracer-Cloud/tracer-client",
         );


### PR DESCRIPTION
Removed Formatted links entirely and replaced with links instead.
At the moment there is no reliable way to check for terminal type or output type.
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/08c4f435-7221-4f11-bf4e-f62f24daefd9" />
