### PR TITLE
Implement auto sizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,6 +2749,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,6 +3339,12 @@ checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
@@ -4685,6 +4697,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "termion"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3669a69de26799d6321a5aa713f55f7e2cd37bd47be044b50f2acafc42c122bb"
+dependencies = [
+ "libc",
+ "libredox",
+ "numtoa",
+ "redox_termios",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5045,6 +5069,7 @@ dependencies = [
  "shlex",
  "sqlx",
  "sysinfo 0.30.13",
+ "termion",
  "tokio",
  "tokio-retry",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,4 @@ bollard = "0.19.0"
 built = { version = "0.8.0", features = ["chrono", "git2"] }
 multi_index_map = "0.15.0"
 tokio-retry = "0.3.0"
+termion= "4.0.5"

--- a/src/tracer/Cargo.toml
+++ b/src/tracer/Cargo.toml
@@ -58,6 +58,7 @@ shlex = { workspace = true }
 bollard = { workspace = true }
 futures-util = { workspace = true }
 multi_index_map = { workspace = true }
+termion = { workspace = true }
 
 [dev-dependencies]
 sqlx = { workspace = true }

--- a/src/tracer/src/cli/handlers/info.rs
+++ b/src/tracer/src/cli/handlers/info.rs
@@ -124,6 +124,7 @@ impl InfoDisplay {
 
         formatter.add_empty_line();
         formatter.add_section_header("Run details");
+        formatter.add_empty_line();
 
         formatter.add_field("Run name", &inner.run_name, "cyan");
         formatter.add_field("Run ID", &inner.run_id, "white");
@@ -174,5 +175,6 @@ impl InfoDisplay {
         formatter.add_field("Standard output", &format!("  {}", STDOUT_FILE), "white");
         formatter.add_field("Err output", &format!("  {}", STDERR_FILE), "white");
         formatter.add_field("Daemon output", &format!("  {}", LOG_FILE), "white");
+        formatter.add_empty_line();
     }
 }

--- a/src/tracer/src/daemon/server/daemon_server.rs
+++ b/src/tracer/src/daemon/server/daemon_server.rs
@@ -74,7 +74,8 @@ impl DaemonServer {
 
     pub async fn terminate(mut self) -> anyhow::Result<()> {
         if self.server.is_some() {
-            panic!("Server not running");
+            eprint!("Server not running");
+            return Ok(());
         }
         self.server.unwrap().abort();
         self.server = None;

--- a/src/tracer/src/utils/cli/box_formatter.rs
+++ b/src/tracer/src/utils/cli/box_formatter.rs
@@ -1,7 +1,7 @@
 use colored::Colorize;
 use console::Emoji;
 use std::fmt::Write;
-
+use termion::terminal_size;
 const STATUS_ACTIVE: Emoji<'_, '_> = Emoji("🟢 ", "🟢 ");
 const STATUS_INACTIVE: Emoji<'_, '_> = Emoji("🔴 ", "🔴 ");
 const STATUS_WARNING: Emoji<'_, '_> = Emoji("🟡 ", "🟡 ");
@@ -18,10 +18,43 @@ impl BoxFormatter {
     pub fn new(width: usize) -> Self {
         Self {
             output: String::new(),
-            width,
+            width: Self::get_width(width),
         }
     }
 
+    /// Create a new BoxFormatter that automatically uses the terminal width
+    pub fn new_auto_width() -> Self {
+        let terminal_width = Self::get_terminal_width();
+        Self {
+            output: String::new(),
+            width: terminal_width,
+        }
+    }
+
+    /// Get the terminal width, with a fallback to a reasonable default
+    fn get_terminal_width() -> usize {
+        match terminal_size() {
+            Ok((width, _)) => {
+                let width = width as usize;
+                // Ensure we have a minimum width and leave some padding
+                if width > 10 {
+                    width - 2 // Leave 2 characters padding
+                } else {
+                    80 // Fallback to 80 characters
+                }
+            }
+            Err(_) => 80, // Fallback to 80 characters if terminal size detection fails
+        }
+    }
+
+    fn get_width(max_width: usize) -> usize {
+        let terminal_width = Self::get_terminal_width();
+        if max_width > terminal_width {
+            terminal_width
+        } else {
+            max_width
+        }
+    }
     pub fn add_header(&mut self, title: &str) {
         writeln!(
             &mut self.output,


### PR DESCRIPTION
## 📌 Summary
<!-- Provide a concise summary of your changes -->
Automatic sizing of the borders when using `tracer info` with termion
Fixed panick/sentry alerts for terminating the daemon
<img width="1646" height="804" alt="image" src="https://github.com/user-attachments/assets/7f070720-887d-40c8-a712-fe5436421d52" />
<img width="1330" height="852" alt="image" src="https://github.com/user-attachments/assets/98be7403-c35a-4cc0-9ed7-f834d70ba395" />
<img width="940" height="872" alt="image" src="https://github.com/user-attachments/assets/ab7a53e5-0de1-4d64-aea5-37989b978344" />

Unfortunately the link is still too long on small windows.
We could use a url shortener(bitly etc) with our new product/app instead of using grafana

Fixes ENG-660 
Fixes ENG-635


