### PR TITLE
Fix target matching for java processes where there are options between

### DIFF
--- a/src/tracer/src/process_identification/target_process/target_manager.rs
+++ b/src/tracer/src/process_identification/target_process/target_manager.rs
@@ -127,7 +127,13 @@ mod tests {
         let manager = TargetManager::new(&rule_files, &[]);
         let process = make_process(
             "/usr/bin/java",
-            &["-Xmx10g", "-jar", "/foo/bar/fgbio.jar", "ZipperBams"],
+            &[
+                "-Xmx10g",
+                "-jar",
+                "/foo/bar/fgbio.jar",
+                "--async-io=true",
+                "ZipperBams",
+            ],
         );
         let matched = manager.get_target_match(&process);
         assert_eq!(matched.as_deref(), Some("fgbio ZipperBams"));


### PR DESCRIPTION
The new java matching rule was not working for fgbio in the fastquorum pipeline because the command has options in between the jar and the subcommand (e.g. `fgbio.jar --tmp-dir=. --async-io=true --compression=1 FastqToBam`).