### PR TITLE
Improve permission checks for commands

### DIFF
--- a/src/tracer/src/cli/handlers/init/handler.rs
+++ b/src/tracer/src/cli/handlers/init/handler.rs
@@ -7,8 +7,9 @@ use crate::daemon::initialization::create_and_run_server;
 use crate::daemon::server::DaemonServer;
 use crate::process_identification::constants::{PID_FILE, STDERR_FILE, STDOUT_FILE};
 use crate::utils::analytics::types::AnalyticsEventType;
-use crate::utils::system_info::check_sudo_privileges;
+use crate::utils::system_info::{is_root, is_sudo};
 use crate::utils::{analytics, Sentry};
+use colored::Colorize;
 use serde_json::Value;
 use std::fs::File;
 use std::process::{Command, Stdio};
@@ -19,7 +20,13 @@ pub fn init(
     api_client: DaemonClient,
 ) -> anyhow::Result<()> {
     // Check if running with sudo
-    check_sudo_privileges();
+    if !is_root() || !is_sudo() {
+        print!(
+            "\n{} `init` requires root privileges. Please run with elevated permissions.",
+            "Warning:".yellow().bold()
+        );
+        return Ok(());
+    }
 
     // Create necessary files for logging and daemonizing
     create_necessary_files().expect("Error while creating necessary files");

--- a/src/tracer/src/cli/handlers/init/handler.rs
+++ b/src/tracer/src/cli/handlers/init/handler.rs
@@ -21,7 +21,7 @@ pub fn init(
 ) -> anyhow::Result<()> {
     // Check if running with sudo
     if !is_root() || !is_sudo() {
-        print!(
+        println!(
             "\n{} `init` requires root privileges. Please run with elevated permissions.",
             "Warning:".yellow().bold()
         );

--- a/src/tracer/src/cli/handlers/uninstall.rs
+++ b/src/tracer/src/cli/handlers/uninstall.rs
@@ -13,7 +13,7 @@ pub fn uninstall() -> Result<()> {
     }
 
     if !is_root() || !is_sudo() {
-        print!(
+        println!(
             "\n{} `uninstall` requires root privileges. Please run with elevated permissions.",
             "Warning:".yellow().bold()
         );

--- a/src/tracer/src/cli/handlers/uninstall.rs
+++ b/src/tracer/src/cli/handlers/uninstall.rs
@@ -14,8 +14,8 @@ pub fn uninstall() -> Result<()> {
 
     if !is_root() || !is_sudo() {
         print!(
-            "\n{} Tracer uninstall requires root privileges. Please run with elevated permissions.",
-            "Warning:".yellow()
+            "\n{} `uninstall` requires root privileges. Please run with elevated permissions.",
+            "Warning:".yellow().bold()
         );
         return Ok(());
     }

--- a/src/tracer/src/cli/process_command.rs
+++ b/src/tracer/src/cli/process_command.rs
@@ -28,11 +28,9 @@ pub fn process_command() -> Result<()> {
     match cli.command {
         Command::Init(args) => handlers::init(*args, config, api_client),
         Command::Cleanup => {
-            let result = DaemonServer::cleanup();
-            if result.is_ok() {
-                println!("Daemon files cleaned up successfully.");
-            }
-            result
+            DaemonServer::cleanup();
+            println!("Daemon files cleanup completed.");
+            Ok(())
         }
         Command::Version => {
             println!("{}", Version::current());

--- a/src/tracer/src/cli/process_daemon_command.rs
+++ b/src/tracer/src/cli/process_daemon_command.rs
@@ -51,7 +51,7 @@ async fn process_retryable_daemon_command_async(
 ) -> DaemonResult<bool> {
     match command {
         Command::Terminate => {
-            if !DaemonServer::is_running(){
+            if !DaemonServer::is_running() {
                 println!("Daemon server is not running, nothing to terminate.");
                 return Ok(true);
             }

--- a/src/tracer/src/daemon/server/daemon_server.rs
+++ b/src/tracer/src/daemon/server/daemon_server.rs
@@ -84,7 +84,7 @@ impl DaemonServer {
         println!("[daemon_server] Monitor loop exited");
         info!("[daemon_server] Monitor loop exited");
         self.terminate().await?;
-        DaemonServer::cleanup()?;
+        DaemonServer::cleanup();
         Ok(())
     }
 
@@ -138,14 +138,13 @@ impl DaemonServer {
         let port = DEFAULT_DAEMON_PORT;
         let shutdown_successful =
             tokio::runtime::Runtime::new()?.block_on(handle_port_conflict(port));
-        DaemonServer::cleanup()?;
+        DaemonServer::cleanup();
         shutdown_successful
     }
 
-    pub fn cleanup() -> anyhow::Result<()> {
+    pub fn cleanup() {
         let _ = std::fs::remove_file(PID_FILE);
         let _ = std::fs::remove_file(STDOUT_FILE);
         let _ = std::fs::remove_file(STDERR_FILE);
-        Ok(())
     }
 }

--- a/src/tracer/src/utils/system_info.rs
+++ b/src/tracer/src/utils/system_info.rs
@@ -1,18 +1,6 @@
 use std::process::Command;
 use tracing::error;
 
-pub fn check_sudo_privileges() {
-    if !is_sudo() && !is_root() {
-        println!("⚠️ Warning: Running without sudo privileges. Some operations may fail.");
-        // Get the current executable path and arguments
-        let current_exe =
-            std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("tracer"));
-        let args: Vec<String> = std::env::args().collect();
-        let sudo_command = format!("sudo {} {}", current_exe.display(), args[1..].join(" "));
-        println!("Try running with elevated privileges:\n {}", sudo_command);
-    }
-}
-
 pub fn is_root() -> bool {
     Command::new("id")
         .arg("-u")


### PR DESCRIPTION
## 🧪 Testing
To install tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | CLI_BRANCH="branch_name" sh && source ~/.bashrc && source ~/.zshrc`

To use the installer of tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | INS_BRANCH="branch_name" sh && source ~/.bashrc && source ~/.zshrc` 


## 📌 Summary
<!-- Provide a concise summary of your changes -->
Fixed terminate command showing logging errors

Replaced init sudo warning with hard exit warning
<img width="698" height="28" alt="image" src="https://github.com/user-attachments/assets/5e7ea614-30b4-4464-8f15-92fb31819593" />

