### PR TITLE
 Annotate Installer with Sentry Tags, Relocate to /usr/local/bin, and Update EC2 Metadata Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1329,12 +1329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,9 +1355,10 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 [[package]]
 name = "ec2_instance_metadata"
 version = "0.3.0"
-source = "git+https://github.com/Tracer-Cloud/ec2-instance-metadata-rs.git?branch=master#b641e5180ba875dd3a8e1fd66abb16dc07632c9e"
+source = "git+https://github.com/Tracer-Cloud/ec2-instance-metadata-rs.git?branch=master#3e0c6dc7243516dfbdd893bf757b6512190d568a"
 dependencies = [
- "json",
+ "serde",
+ "serde_json",
  "ureq",
 ]
 
@@ -2299,12 +2294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
 name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,7 +2348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4788,7 +4777,7 @@ dependencies = [
  "dashmap",
  "dialoguer",
  "dirs",
- "dotenv",
+ "dotenvy",
  "ec2_instance_metadata",
  "futures-util",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,8 +169,8 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.3.1",
- "ring 0.17.14",
- "time 0.3.41",
+ "ring",
+ "time",
  "tokio",
  "tracing",
  "url",
@@ -425,10 +425,10 @@ dependencies = [
  "http 1.3.1",
  "p256",
  "percent-encoding",
- "ring 0.17.14",
+ "ring",
  "sha2",
  "subtle",
- "time 0.3.41",
+ "time",
  "tracing",
  "zeroize",
 ]
@@ -459,7 +459,7 @@ dependencies = [
  "http-body 0.4.6",
  "md-5",
  "pin-project-lite",
- "sha1 0.10.6",
+ "sha1",
  "sha2",
  "tracing",
 ]
@@ -615,7 +615,7 @@ dependencies = [
  "pin-utils",
  "ryu",
  "serde",
- "time 0.3.41",
+ "time",
  "tokio",
  "tokio-util",
 ]
@@ -639,7 +639,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "rustc_version 0.4.1",
+ "rustc_version",
  "tracing",
 ]
 
@@ -713,22 +713,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -936,12 +924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
-
-[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,12 +1053,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const_fn"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
-
-[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,33 +1068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "cookie"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
-dependencies = [
- "percent-encoding",
- "time 0.2.27",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3818dfca4b0cb5211a659bbcbb94225b7127407b2b135e650d717bfb78ab10d3"
-dependencies = [
- "cookie",
- "idna 0.2.3",
- "log",
- "publicsuffix",
- "serde",
- "serde_json",
- "time 0.2.27",
- "url",
 ]
 
 [[package]]
@@ -1369,12 +1318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,11 +1361,10 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 [[package]]
 name = "ec2_instance_metadata"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e6c7cd17abc12088c36a718be748fd1d9914a2dc310a28babccc6a657c284b"
+source = "git+https://github.com/Tracer-Cloud/ec2-instance-metadata-rs.git?branch=master#b641e5180ba875dd3a8e1fd66abb16dc07632c9e"
 dependencies = [
  "json",
- "ureq 1.5.5",
+ "ureq",
 ]
 
 [[package]]
@@ -1565,7 +1507,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -2225,17 +2167,6 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
@@ -2382,7 +2313,7 @@ dependencies = [
  "base64 0.22.1",
  "js-sys",
  "pem",
- "ring 0.17.14",
+ "ring",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -2394,7 +2325,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -2550,12 +2481,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -3175,37 +3100,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "publicsuffix"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4ce31ff0a27d93c8de1849cf58162283752f065a90d508f1105fa6c9a213f"
-dependencies = [
- "idna 0.2.3",
- "url",
-]
-
-[[package]]
-name = "qstring"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-dependencies = [
- "percent-encoding",
 ]
 
 [[package]]
@@ -3238,7 +3138,7 @@ dependencies = [
  "getrandom 0.3.3",
  "lru-slab",
  "rand 0.9.1",
- "ring 0.17.14",
+ "ring",
  "rustc-hash 2.1.1",
  "rustls 0.23.29",
  "rustls-pki-types",
@@ -3494,21 +3394,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -3517,7 +3402,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3550,7 +3435,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version 0.4.1",
+ "rustc_version",
 ]
 
 [[package]]
@@ -3566,7 +3451,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "rustc_version 0.4.1",
+ "rustc_version",
  "syn 2.0.104",
  "unicode-ident",
 ]
@@ -3591,20 +3476,11 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.26",
+ "semver",
 ]
 
 [[package]]
@@ -3635,27 +3511,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.1",
- "log",
- "ring 0.16.20",
- "sct 0.6.1",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.14",
+ "ring",
  "rustls-webpki 0.101.7",
- "sct 0.7.1",
+ "sct",
 ]
 
 [[package]]
@@ -3667,7 +3530,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.4",
  "subtle",
@@ -3732,8 +3595,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3743,9 +3606,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -3810,22 +3673,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
-
-[[package]]
-name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3895,24 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
@@ -3929,7 +3767,7 @@ dependencies = [
  "sentry-panic",
  "sentry-tracing",
  "tokio",
- "ureq 3.0.12",
+ "ureq",
 ]
 
 [[package]]
@@ -4001,7 +3839,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "time 0.3.41",
+ "time",
  "url",
  "uuid",
 ]
@@ -4131,7 +3969,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time 0.3.41",
+ "time",
 ]
 
 [[package]]
@@ -4161,15 +3999,6 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
@@ -4178,12 +4007,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -4255,7 +4078,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror 2.0.12",
- "time 0.3.41",
+ "time",
 ]
 
 [[package]]
@@ -4303,12 +4126,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -4460,7 +4277,7 @@ dependencies = [
  "rand 0.8.5",
  "rsa",
  "serde",
- "sha1 0.10.6",
+ "sha1",
  "sha2",
  "smallvec",
  "sqlx-core",
@@ -4538,64 +4355,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1 0.6.1",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stringprep"
@@ -4769,21 +4528,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros 0.1.1",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
@@ -4796,7 +4540,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.22",
+ "time-macros",
 ]
 
 [[package]]
@@ -4807,35 +4551,12 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5113,6 +4834,7 @@ dependencies = [
  "colored",
  "console 0.16.0",
  "dirs",
+ "ec2_instance_metadata",
  "flate2",
  "futures-util",
  "indicatif",
@@ -5159,7 +4881,7 @@ checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
  "thiserror 1.0.69",
- "time 0.3.41",
+ "time",
  "tracing-subscriber",
 ]
 
@@ -5220,7 +4942,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.41",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -5306,34 +5028,9 @@ checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8b063c2d59218ae09f22b53c42eaad0d53516457905f5235ca4bc9e99daa71"
-dependencies = [
- "base64 0.13.1",
- "chunked_transfer",
- "cookie",
- "cookie_store",
- "log",
- "once_cell",
- "qstring",
- "rustls 0.19.1",
- "url",
- "webpki",
- "webpki-roots 0.21.1",
-]
 
 [[package]]
 name = "ureq"
@@ -5342,6 +5039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
 dependencies = [
  "base64 0.22.1",
+ "flate2",
  "log",
  "percent-encoding",
  "rustls 0.23.29",
@@ -5371,7 +5069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.3",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -5588,25 +5286,6 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ sqlx = { version = "0.8.6", features = [
     "chrono",
 ] }
 
-ec2_instance_metadata = "0.3.0"
+ec2_instance_metadata = { git = "https://github.com/Tracer-Cloud/ec2-instance-metadata-rs.git", branch = "master" }
+
 rand = "0.9.1"
 uuid = { version = "1.17.0", features = [
     "v4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ config = { version = "0.15.13", default-features = false, features = [
     "convert-case",
 ] }
 serial_test = "3.2.0"
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 sentry = { version = "0.41.0", default-features = false, features = [
     "anyhow",
     "backtrace",

--- a/installation.sh
+++ b/installation.sh
@@ -55,7 +55,7 @@ fi
 TRACER_HOME="$HOME/.tracerbio"
 
 PACKAGE_NAME="" # set later
-BINDIRS=("$HOME/bin" "$HOME/.local/bin" "$TRACER_HOME/bin")
+BINDIRS=("/usr/local/bin" "$HOME/bin" "$HOME/.local/bin" "$TRACER_HOME/bin")
 BINDIR="" # set later
 API_KEY="" # set later
 SUID_SETUP_FAILED=false  # Flag for SUID setup status

--- a/src/tracer-installer/Cargo.toml
+++ b/src/tracer-installer/Cargo.toml
@@ -22,7 +22,7 @@ rustls = {workspace = true }
 tokio-retry = {workspace = true }
 sentry = {workspace = true }
 sysinfo = {workspace = true }
-
+ec2_instance_metadata = { workspace = true }
 
 indicatif = "0.18.0"
 async-trait = "0.1.88"

--- a/src/tracer-installer/src/checks/environment.rs
+++ b/src/tracer-installer/src/checks/environment.rs
@@ -87,6 +87,7 @@ pub struct EnvironmentCheck {
 impl EnvironmentCheck {
     pub async fn new() -> Self {
         let detected = detect_environment_type().await;
+        crate::Sentry::add_tag("detected_env", &detected);
         Self { detected }
     }
 }

--- a/src/tracer-installer/src/checks/kernel.rs
+++ b/src/tracer-installer/src/checks/kernel.rs
@@ -60,7 +60,11 @@ impl InstallCheck for KernelCheck {
         }
 
         match Self::get_kernel_version() {
-            Some(version) => Self::is_compatible_kernel(version),
+            Some(version) => {
+                let version_str = format!("{}.{}", version.0, version.1);
+                crate::Sentry::add_tag("kernel_version", &version_str);
+                Self::is_compatible_kernel(version)
+            }
             None => false,
         }
     }

--- a/src/tracer-installer/src/checks/root.rs
+++ b/src/tracer-installer/src/checks/root.rs
@@ -13,7 +13,10 @@ impl RootCheck {
 #[async_trait::async_trait]
 impl InstallCheck for RootCheck {
     async fn check(&self) -> bool {
-        nix::unistd::Uid::effective().is_root()
+        let has_root = nix::unistd::Uid::effective().is_root();
+        let value = if has_root { "true" } else { "false" };
+        crate::Sentry::add_tag("has_root_privileges", value);
+        has_root
     }
     fn name(&self) -> &'static str {
         "Root Privileges Access"

--- a/src/tracer-installer/src/main.rs
+++ b/src/tracer-installer/src/main.rs
@@ -52,7 +52,6 @@ async fn main() {
                 channel,
                 user_id,
             };
-            panic!("Testing out Panics... With Ec2 Contexts");
             if let Err(err) = installer.run().await {
                 eprintln!("Error Running Installer: {err}");
                 std::process::exit(1);

--- a/src/tracer-installer/src/main.rs
+++ b/src/tracer-installer/src/main.rs
@@ -52,6 +52,7 @@ async fn main() {
                 channel,
                 user_id,
             };
+            panic!("Testing out Panics... With Ec2 Contexts");
             if let Err(err) = installer.run().await {
                 eprintln!("Error Running Installer: {err}");
                 std::process::exit(1);

--- a/src/tracer-installer/src/main.rs
+++ b/src/tracer-installer/src/main.rs
@@ -52,12 +52,10 @@ async fn main() {
                 channel,
                 user_id,
             };
-            println!("\n\n different installer  ....\n\n");
             if let Err(err) = installer.run().await {
                 eprintln!("Error Running Installer: {err}");
                 std::process::exit(1);
             }
-            panic!("Just testing... No worries");
         }
     }
 }

--- a/src/tracer-installer/src/main.rs
+++ b/src/tracer-installer/src/main.rs
@@ -52,10 +52,12 @@ async fn main() {
                 channel,
                 user_id,
             };
+            println!("\n\n different installer  ....\n\n");
             if let Err(err) = installer.run().await {
                 eprintln!("Error Running Installer: {err}");
                 std::process::exit(1);
             }
+            panic!("Just testing... No worries");
         }
     }
 }

--- a/src/tracer/Cargo.toml
+++ b/src/tracer/Cargo.toml
@@ -63,7 +63,7 @@ termion = { workspace = true }
 
 [dev-dependencies]
 sqlx = { workspace = true }
-dotenv = { workspace = true }
+dotenvy = { workspace = true }
 serial_test = { workspace = true }
 uuid = { workspace = true }
 rstest = { workspace = true }

--- a/src/tracer/src/cli/handlers/uninstall.rs
+++ b/src/tracer/src/cli/handlers/uninstall.rs
@@ -6,6 +6,8 @@ use colored::Colorize;
 use std::fs;
 use std::path::Path;
 
+const INSTALL_PATH: &str = "/usr/local/bin/tracer";
+
 pub fn uninstall() -> Result<()> {
     if DaemonServer::is_running() {
         println!("\n{} Tracer daemon is currently running. Please run `tracer terminate` before uninstalling", "Warning:".yellow());
@@ -35,19 +37,16 @@ pub fn uninstall() -> Result<()> {
 }
 
 fn remove_binary() -> Result<()> {
-    let current_exe = std::env::current_exe().context("failed to get current exe path")?;
+    let tracer_path = Path::new(INSTALL_PATH);
 
-    let current_dir = current_exe
-        .parent()
-        .context("failed to get parent directory of binary")?;
-
-    println!("🔍 Binary path: {}", current_exe.display());
-    println!("📂 Directory containing binary: {}", current_dir.display());
-
-    fs::remove_file(&current_exe)
-        .with_context(|| format!("Failed to remove binary at {}", current_exe.display()))?;
-
-    println!("✅  Binary removed successfully");
+    if tracer_path.exists() {
+        println!("🔍 Binary path: {}", tracer_path.display());
+        fs::remove_file(tracer_path)
+            .with_context(|| format!("Failed to remove binary at {}", tracer_path.display()))?;
+        println!("✅  Binary removed successfully");
+    } else {
+        println!("⚠️  Binary not found at: {}", tracer_path.display());
+    }
 
     Ok(())
 }
@@ -63,7 +62,7 @@ fn remove_env_paths() -> Result<()> {
         }
     }
 
-    println!("✅  Tracer environment file removed");
+    println!("✅  Tracer environment variables removed (if any)");
     Ok(())
 }
 

--- a/src/tracer/src/cloud_providers/aws/s3.rs
+++ b/src/tracer/src/cloud_providers/aws/s3.rs
@@ -221,7 +221,7 @@ impl S3Client {
 pub mod tests {
     use super::*;
     use aws_config::meta::region::RegionProviderChain;
-    use dotenv::dotenv;
+    use dotenvy::dotenv;
     use serial_test::serial;
     use std::env;
     use tokio::time::{sleep, Duration};


### PR DESCRIPTION
## 🧪 Testing
To install tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | CLI_BRANCH="branch_name" sh && source ~/.bashrc && source ~/.zshrc`

To use the installer of tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | INS_BRANCH="branch_name" sh && source ~/.bashrc && source ~/.zshrc` 


## 📌 Summary
<!-- Provide a concise summary of your changes -->

- Binary Relocation: Moves tracer binary from $HOME/.tracerbio/bin to /usr/local/bin for global access by all users.
-  EC2 Metadata Upgrade: Bumps ec2-instance-metadata crate to patched fork to resolve security advisory.
   - 🔗 Forked crate now hosted under [tracercloud/ec2-instance-metadata-rs](https://github.com/Tracer-Cloud/ec2-instance-metadata-rs).

## 🔍 Related Issues/Tickets
<!-- Link to related issues or tickets, e.g., Closes #123 -->

## ✨ Changes Introduced
<!-- Briefly describe the changes in this PR -->

## ✨ Infrastructure Impact
<!-- Briefly describe if there is some impact to our infrastructure -->


## ✅ Checklist
- [ ] Code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and they work as expected
- [ ] Documentation has been updated if needed
- [ ] Tests have been added or updated

## 🛠️ How to Test
<!-- Provide instructions on how to test your changes -->

## 🚀 Screenshots (if applicable)
<!-- Add screenshots or GIFs to demonstrate the changes -->

## 📌 Additional Notes
<!-- Add any other relevant information -->
