### PR TITLE
Add `tool_id` to uniquely identify a tool

### DIFF
--- a/src/tracer/src/process_identification/types/event/attributes/process.rs
+++ b/src/tracer/src/process_identification/types/event/attributes/process.rs
@@ -34,6 +34,7 @@ pub struct FullProcessProperties {
     pub working_directory: Option<String>,
     pub trace_id: Option<String>,
     pub container_event: Option<ContainerEvent>,
+    pub tool_id: String, // the tool_id is useful to uniquely identify a tool
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
## 🧪 Testing
To install tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | CLI_BRANCH="feature/tool-unique-identification" sh && source ~/.bashrc && source ~/.zshrc`

To use the installer of tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | INS_BRANCH="tool-unique-identification" sh && source ~/.bashrc && source ~/.zshrc` 


## 📌 Summary
Add new field `tool_id` to the process attributes to uniquely identify one tool

`tool_id` is added in the format `PID-timestamp_nanosecond` so something like  `13040-1753128621142935000`

<img width="766" height="785" alt="image" src="https://github.com/user-attachments/assets/73212810-9c7e-4933-a95d-c8983b7e05e8" />

## 🔍 Related Issues/Tickets
<!-- Link to related issues or tickets, e.g., Closes #123 -->

## ✨ Changes Introduced
<!-- Briefly describe the changes in this PR -->

## ✨ Infrastructure Impact
<!-- Briefly describe if there is some impact to our infrastructure -->


## ✅ Checklist
- [ ] Code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and they work as expected
- [ ] Documentation has been updated if needed
- [ ] Tests have been added or updated

## 🛠️ How to Test
<!-- Provide instructions on how to test your changes -->

## 🚀 Screenshots (if applicable)
<!-- Add screenshots or GIFs to demonstrate the changes -->

## 📌 Additional Notes
<!-- Add any other relevant information -->
