### PR TITLE
Implement daemon logging

### DIFF
--- a/src/tracer/src/cli/handlers/init/arguments.rs
+++ b/src/tracer/src/cli/handlers/init/arguments.rs
@@ -39,6 +39,12 @@ pub struct TracerCliInitArgs {
     // For testing purposes only
     #[clap(long, hide = true)]
     pub is_dev: Option<bool>,
+
+    /// Capture logs at the specified level and above (default: info)
+    /// Valid values: trace, debug, info, warn, error
+    /// Output will be written to `daemon.log` in the working directory.
+    #[clap(long, default_value = "info")]
+    pub log_level: String,
 }
 
 impl TracerCliInitArgs {
@@ -192,6 +198,7 @@ impl TracerCliInitArgs {
             no_daemonize: self.no_daemonize,
             is_dev: self.is_dev,
             user_id: self.user_id,
+            log_level: self.log_level,
         }
     }
 }
@@ -206,4 +213,5 @@ pub struct FinalizedInitArgs {
     pub no_daemonize: bool,
     pub is_dev: Option<bool>,
     pub user_id: Option<String>,
+    pub log_level: String,
 }

--- a/src/tracer/src/cli/handlers/init/handler.rs
+++ b/src/tracer/src/cli/handlers/init/handler.rs
@@ -5,14 +5,20 @@ use crate::config::Config;
 use crate::daemon::client::DaemonClient;
 use crate::daemon::initialization::create_and_run_server;
 use crate::daemon::server::DaemonServer;
-use crate::process_identification::constants::{PID_FILE, STDERR_FILE, STDOUT_FILE};
+use crate::process_identification::constants::{
+    LOG_FILE, PID_FILE, STDERR_FILE, STDOUT_FILE, WORKING_DIR,
+};
 use crate::utils::analytics::types::AnalyticsEventType;
 use crate::utils::system_info::check_sudo;
 use crate::utils::{analytics, Sentry};
+use anyhow::Context;
 use serde_json::Value;
 use std::fs::File;
 use std::process::{Command, Stdio};
-
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
+use tracing_subscriber::fmt::time::SystemTime;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{fmt, EnvFilter};
 pub async fn init(
     args: TracerCliInitArgs,
     config: Config,
@@ -67,6 +73,8 @@ pub async fn init(
             .arg(args.tags.user_operator.as_deref().unwrap_or(""))
             .arg("--is-dev")
             .arg(args.is_dev.unwrap_or_default().to_string())
+            .arg("--log-level")
+            .arg(args.log_level)
             .stdin(Stdio::null())
             .stdout(Stdio::from(File::create(STDOUT_FILE)?))
             .stderr(Stdio::from(File::create(STDERR_FILE)?))
@@ -88,6 +96,40 @@ pub async fn init(
 
         return Ok(());
     }
+    setup_logging(&args.log_level)?;
 
     create_and_run_server(args, config).await
+}
+
+fn setup_logging(log_level: &String) -> anyhow::Result<()> {
+    // Set up the filter
+    // Capture all levels from log_level and up
+    let filter = EnvFilter::from(log_level);
+
+    // Create a file appender that writes to daemon.log
+    let file_appender = RollingFileAppender::new(Rotation::NEVER, WORKING_DIR, "daemon.log");
+
+    // Create a custom format for the logs without colors
+    let file_layer = fmt::layer()
+        .with_file(true)
+        .with_line_number(true)
+        .with_thread_ids(true)
+        .with_thread_names(true)
+        .with_target(true)
+        .with_level(true)
+        .with_timer(SystemTime)
+        .with_ansi(false) // This disables ANSI color codes
+        .with_writer(file_appender);
+
+    // Set up the subscriber with our custom layer
+    let subscriber = tracing_subscriber::registry().with(filter).with(file_layer);
+
+    // Set the subscriber as the default
+    tracing::subscriber::set_global_default(subscriber)
+        .context("Failed to set tracing subscriber")?;
+
+    // Log initialization message
+    tracing::info!("Logging system initialized. Writing to {}", LOG_FILE);
+
+    Ok(())
 }

--- a/src/tracer/src/extracts/ebpf_watcher/handler/trigger/trigger_processor.rs
+++ b/src/tracer/src/extracts/ebpf_watcher/handler/trigger/trigger_processor.rs
@@ -65,10 +65,6 @@ impl TriggerProcessor {
         process_start_triggers: Vec<ProcessStartTrigger>,
     ) -> Result<()> {
         if !process_start_triggers.is_empty() {
-            info!(
-                "Processing {} process start triggers",
-                process_start_triggers.len()
-            );
             for trigger in &process_start_triggers {
                 debug!(
                     "Processing start trigger - PID: {}, Name: {}, Parent PID: {}",

--- a/src/tracer/src/process_identification/utils.rs
+++ b/src/tracer/src/process_identification/utils.rs
@@ -5,7 +5,7 @@ use serde_json::{Map, Value};
 use std::fs::OpenOptions;
 use std::io::Write;
 use tracer_ebpf::ebpf_trigger::ProcessStartTrigger;
-use tracing::error;
+use tracing::{error, info};
 
 /// Flattens the `attributes` field of an event with prefixing, e.g.:
 /// `process.tool_name` or `system_properties.ec2_cost_per_hour`
@@ -70,7 +70,7 @@ pub fn log_matched_process(trigger: &ProcessStartTrigger, matched_rule: &str, is
         matched_string,
         matched_rule,
     );
-
+    info!(log_line);
     if let Err(e) = OpenOptions::new()
         .create(true)
         .append(true)


### PR DESCRIPTION
## 🧪 Testing
To install tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | CLI_BRANCH="branch_name" sh && source ~/.bashrc && source ~/.zshrc`

To use the installer of tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | INS_BRANCH="branch_name" sh && source ~/.bashrc && source ~/.zshrc` 


## 📌 Summary
<!-- Provide a concise summary of your changes -->
Implemented a log-level argument for tracer init.
Default value is info.

We need to reprioritise certain logs from info-> debug.
Only the important logs should be outputted at all times.

## 🔍 Related Issues/Tickets
<!-- Link to related issues or tickets, e.g., Closes #123 -->
Closes ENG-690
https://linear.app/tracercloud/issue/ENG-690/check-why-and-fix-daemonlog-file-is-not-always-written-everywhere
