### PR TITLE
fix: update run dashboard link

### DIFF
--- a/src/tracer/src/daemon/structs.rs
+++ b/src/tracer/src/daemon/structs.rs
@@ -136,7 +136,7 @@ impl InnerInfoResponse {
     pub fn get_run_url(&self) -> String {
         format!(
             "{}/{}/{}",
-            DASHBOARD_BASE, self.pipeline_name, self.run_name
+            DASHBOARD_BASE, self.pipeline_name, self.run_id
         )
     }
     pub fn total_runtime(&self) -> TimeDelta {

--- a/src/tracer/src/daemon/structs.rs
+++ b/src/tracer/src/daemon/structs.rs
@@ -134,10 +134,7 @@ impl TryFrom<PipelineMetadata> for InnerInfoResponse {
 
 impl InnerInfoResponse {
     pub fn get_run_url(&self) -> String {
-        format!(
-            "{}/{}/{}",
-            DASHBOARD_BASE, self.pipeline_name, self.run_id
-        )
+        format!("{}/{}/{}", DASHBOARD_BASE, self.pipeline_name, self.run_id)
     }
     pub fn total_runtime(&self) -> TimeDelta {
         Utc::now() - self.start_time


### PR DESCRIPTION
Updates the run dashboard url to have run_id instead or run_name