### PR TITLE
Resolve semgrep issue around child process spawning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4779,6 +4779,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "mockall",
+ "nix",
  "octocrab",
  "percent-encoding",
  "pretty_assertions_sorted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,9 @@ git2 = { version = "0.20.2", features = [
 ], default-features = false }
 which = "8.0.0"
 enquote = "1.1.0"
+
+indicatif = "0.18.0"
+async-trait = "0.1.88"
+nix = { version = "0.30.1", features = ["user", "process", "fs"] }
+tar = "0.4.44"
+flate2 = "1.1.2"

--- a/src/tracer-installer/Cargo.toml
+++ b/src/tracer-installer/Cargo.toml
@@ -14,18 +14,18 @@ serde = { workspace = true }
 tokio = { workspace = true }
 console = { workspace = true }
 colored = { workspace = true }
-futures-util = {workspace = true }
-tempfile = {workspace = true }
-dirs = {workspace = true }
-clap = {workspace = true }
-rustls = {workspace = true }
-tokio-retry = {workspace = true }
-sentry = {workspace = true }
-sysinfo = {workspace = true }
+futures-util = { workspace = true }
+tempfile = { workspace = true }
+dirs = { workspace = true }
+clap = { workspace = true }
+rustls = { workspace = true }
+tokio-retry = { workspace = true }
+sentry = { workspace = true }
+sysinfo = { workspace = true }
 ec2_instance_metadata = { workspace = true }
 
-indicatif = "0.18.0"
-async-trait = "0.1.88"
-nix = { version = "0.30.1", features = ["user"]}
-tar = "0.4.44"
-flate2 = "1.1.2"
+indicatif = { workspace = true }
+async-trait = { workspace = true }
+nix = { workspace = true }
+tar = { workspace = true }
+flate2 = { workspace = true }

--- a/src/tracer/Cargo.toml
+++ b/src/tracer/Cargo.toml
@@ -61,6 +61,7 @@ dashmap = { workspace = true }
 termion = { workspace = true }
 git2 = { workspace = true }
 which = { workspace = true }
+nix = { workspace = true }
 
 [dev-dependencies]
 sqlx = { workspace = true }

--- a/src/tracer/src/cli/handlers/init/mod.rs
+++ b/src/tracer/src/cli/handlers/init/mod.rs
@@ -1,4 +1,8 @@
 pub mod arguments;
 mod handler;
+mod spawn;
 
 pub use handler::{init, init_with_default_prompt};
+pub use spawn::spawn_child;
+#[cfg(not(target_os = "linux"))]
+pub use spawn::resolve_exe_path;

--- a/src/tracer/src/cli/handlers/init/mod.rs
+++ b/src/tracer/src/cli/handlers/init/mod.rs
@@ -3,6 +3,4 @@ mod handler;
 mod spawn;
 
 pub use handler::{init, init_with_default_prompt};
-pub use spawn::spawn_child;
-#[cfg(not(target_os = "linux"))]
-pub use spawn::resolve_exe_path;
+pub use spawn::{resolve_exe_path, spawn_child};

--- a/src/tracer/src/cli/handlers/init/spawn.rs
+++ b/src/tracer/src/cli/handlers/init/spawn.rs
@@ -1,0 +1,118 @@
+use anyhow::Result;
+
+#[cfg(not(target_os = "linux"))]
+pub use no_linux::resolve_exe_path;
+
+pub fn spawn_child(args: &[&str]) -> Result<u32> {
+    #[cfg(target_os = "linux")]
+    let pid = linux::spawn_child(exe, args)?;
+
+    #[cfg(not(target_os = "linux"))]
+    let pid = no_linux::spawn_child(args)?;
+
+    Ok(pid)
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use crate::utils::workdir::TRACER_WORK_DIR;
+    use anyhow::Result;
+    use nix::fcntl::{self, OFlag};
+    use nix::sys::stat::Mode;
+    use std::fs::File;
+    use std::os::fd::AsRawFd;
+    use std::process::{Command, Stdio};
+
+    pub fn spawn_child(args: &[&str]) -> Result<u32> {
+        // Open a stable handle to our own binary
+        // Use O_RDONLY - kernel ensures it's the same inode we're running.
+        let fd = fcntl::open("/proc/self/exe", OFlag::O_RDONLY, Mode::empty())?;
+
+        // Convert FD into a path we can execute
+        let proc_path = format!("/proc/self/fd/{}", fd.as_raw_fd());
+
+        // Spawn child process
+        let child = Command::new(proc_path)
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(File::create(&TRACER_WORK_DIR.stdout_file)?))
+            .stderr(Stdio::from(File::create(&TRACER_WORK_DIR.stderr_file)?))
+            .spawn()?;
+
+        Ok(child.id())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod no_linux {
+    use crate::utils::workdir::TRACER_WORK_DIR;
+    use anyhow::Result;
+    use std::fs::{self, File};
+    use std::path::{self, Path, PathBuf};
+    use std::process::{Command, Stdio};
+    use std::sync::LazyLock;
+    use std::{env, io, os};
+
+    /// Resolve a *trusted* absolute path to this binary without current_exe().
+    /// Strategy:
+    /// 1) If you have a build-time constant or config, use that.
+    /// 2) Else, resolve argv[0] via PATH + canonicalize, then validate.
+    static CANONICAL_EXE_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
+        let path_str = env::args().next().expect("argv is empty");
+        let path = if path_str.contains(path::MAIN_SEPARATOR) {
+            PathBuf::from(path_str)
+        } else {
+            which::which(path_str).expect("could not get absolute path for executable")
+        };
+        fs::canonicalize(&path).expect("could not get canonical path for executable")
+    });
+
+    pub fn resolve_exe_path() {
+        std::sync::LazyLock::force(&CANONICAL_EXE_PATH);
+    }
+
+    pub fn spawn_child(args: &[&str]) -> Result<u32> {
+        let exe = &*CANONICAL_EXE_PATH;
+
+        validate_path_secure(exe)?;
+
+        let child = Command::new(exe)
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(File::create(&TRACER_WORK_DIR.stdout_file)?))
+            .stderr(Stdio::from(File::create(&TRACER_WORK_DIR.stderr_file)?))
+            .spawn()?;
+
+        Ok(child.id())
+    }
+
+    /// Minimal checks to reduce risk: path exists, is a file, and components aren’t world-writable.
+    /// (You can expand this to check ownership, mode bits, codesign, etc.)
+    fn validate_path_secure(path: &Path) -> io::Result<()> {
+        let meta = fs::metadata(path)?;
+        if !meta.is_file() {
+            return Err(io::Error::new(io::ErrorKind::Other, "not a file"));
+        }
+        // Walk parents and ensure no component is world-writable.
+        let mut cur = path;
+        while let Some(dir) = cur.parent() {
+            let m = fs::metadata(dir)?;
+            #[cfg(unix)]
+            {
+                use os::unix::fs::MetadataExt;
+                let mode = m.mode();
+                if mode & 0o002 != 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "world-writable path component",
+                    ));
+                }
+            }
+            cur = dir;
+            if cur.as_os_str().is_empty() {
+                break;
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/tracer/src/cli/handlers/mod.rs
+++ b/src/tracer/src/cli/handlers/mod.rs
@@ -11,6 +11,8 @@ pub(super) use cleanup_port::cleanup_port;
 pub(super) use info::info;
 pub use init::arguments as init_arguments;
 pub(super) use init::init;
+#[cfg(not(target_os = "linux"))]
+pub use init::resolve_exe_path;
 pub(super) use terminate::terminate;
 pub use test::arguments as test_arguments;
 pub(super) use test::test;

--- a/src/tracer/src/cli/handlers/mod.rs
+++ b/src/tracer/src/cli/handlers/mod.rs
@@ -11,7 +11,6 @@ pub(super) use cleanup_port::cleanup_port;
 pub(super) use info::info;
 pub use init::arguments as init_arguments;
 pub(super) use init::init;
-#[cfg(not(target_os = "linux"))]
 pub use init::resolve_exe_path;
 pub(super) use terminate::terminate;
 pub use test::arguments as test_arguments;

--- a/src/tracer/src/cli/mod.rs
+++ b/src/tracer/src/cli/mod.rs
@@ -4,7 +4,6 @@ mod helper;
 mod process_command;
 mod process_daemon_command;
 
-#[cfg(not(target_os = "linux"))]
 pub use handlers::resolve_exe_path;
 pub use process_command::process_command;
 pub use process_daemon_command::process_daemon_command;

--- a/src/tracer/src/cli/mod.rs
+++ b/src/tracer/src/cli/mod.rs
@@ -4,5 +4,7 @@ mod helper;
 mod process_command;
 mod process_daemon_command;
 
+#[cfg(not(target_os = "linux"))]
+pub use handlers::resolve_exe_path;
 pub use process_command::process_command;
 pub use process_daemon_command::process_daemon_command;

--- a/src/tracer/src/main.rs
+++ b/src/tracer/src/main.rs
@@ -1,9 +1,15 @@
 use tracer::cli;
 
 pub fn main() -> anyhow::Result<()> {
+    // immediately resolve the executable path - needed for spawning the
+    // daemon on non-linux systems
+    #[cfg(not(target_os = "linux"))]
+    cli::resolve_exe_path();
+    // initialize the crypto provider for TLS
     rustls::crypto::ring::default_provider()
         .install_default()
         .map_err(|e| anyhow::anyhow!("Failed to install default crypto provider: {:?}", e))?;
+    // process the command line
     cli::process_command();
     Ok(())
 }

--- a/src/tracer/src/main.rs
+++ b/src/tracer/src/main.rs
@@ -3,7 +3,6 @@ use tracer::cli;
 pub fn main() -> anyhow::Result<()> {
     // immediately resolve the executable path - needed for spawning the
     // daemon on non-linux systems
-    #[cfg(not(target_os = "linux"))]
     cli::resolve_exe_path();
     // initialize the crypto provider for TLS
     rustls::crypto::ring::default_provider()


### PR DESCRIPTION
Remove use of `std::env::current_exe`, which semgrep flags as insecure.

Instead, we use `/proc/self/exe` on linux. If that doesn't work, or we're on a non-linux system, then we capture `argv[0]` as soon as the program starts, and when it's time to spawn the process we validate the path.

## 🧪 Testing
To install tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | CLI_BRANCH="branch_name" sh`

To use the installer of tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | INS_BRANCH="branch_name" sh`


## 📌 Summary
<!-- Provide a concise summary of your changes -->

## 🔍 Related Issues/Tickets
<!-- Link to related issues or tickets, e.g., Closes #123 -->

## ✨ Changes Introduced
<!-- Briefly describe the changes in this PR -->

## ✨ Infrastructure Impact
<!-- Briefly describe if there is some impact to our infrastructure -->


## ✅ Checklist
- [ ] Code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and they work as expected
- [ ] Documentation has been updated if needed
- [ ] Tests have been added or updated

## 🛠️ How to Test
<!-- Provide instructions on how to test your changes -->

## 🚀 Screenshots (if applicable)
<!-- Add screenshots or GIFs to demonstrate the changes -->

## 📌 Additional Notes
<!-- Add any other relevant information -->
