### PR TITLE
replace dirs (abandoned) with dirs_next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,24 +1288,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
+name = "dirs-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "dirs-sys",
+ "cfg-if",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.5.0"
+name = "dirs-sys-next"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "winapi",
 ]
 
 [[package]]
@@ -2788,12 +2788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,13 +3222,13 @@ checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4771,7 +4765,7 @@ dependencies = [
  "console 0.16.0",
  "dashmap",
  "dialoguer",
- "dirs",
+ "dirs-next",
  "dotenvy",
  "ec2_instance_metadata",
  "futures-util",
@@ -4818,7 +4812,7 @@ dependencies = [
  "clap",
  "colored",
  "console 0.16.0",
- "dirs",
+ "dirs-next",
  "ec2_instance_metadata",
  "flate2",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ tracing-subscriber = { version = "0.3.19", features = [
     "time",
     "local-time",
 ] }
-dirs = "6.0.0"
 serde-query = "0.2.0"
 itertools = "0.14.0"
 percent-encoding = "2.3.1"
@@ -105,6 +104,7 @@ git2 = { version = "0.20.2", features = [
 ], default-features = false }
 which = "8.0.0"
 enquote = "1.1.0"
+dirs-next = "2.0.0"
 
 [profile.dev]
 incremental = true

--- a/src/tracer-installer/Cargo.toml
+++ b/src/tracer-installer/Cargo.toml
@@ -13,18 +13,18 @@ serde = { workspace = true }
 tokio = { workspace = true }
 console = { workspace = true }
 colored = { workspace = true }
-futures-util = {workspace = true }
-tempfile = {workspace = true }
-dirs = {workspace = true }
-clap = {workspace = true }
-rustls = {workspace = true }
-tokio-retry = {workspace = true }
-sentry = {workspace = true }
-sysinfo = {workspace = true }
+futures-util = { workspace = true }
+tempfile = { workspace = true }
+dirs-next = { workspace = true }
+clap = { workspace = true }
+rustls = { workspace = true }
+tokio-retry = { workspace = true }
+sentry = { workspace = true }
+sysinfo = { workspace = true }
 ec2_instance_metadata = { workspace = true }
 
 indicatif = "0.18.0"
 async-trait = "0.1.88"
-nix = { version = "0.30.1", features = ["user"]}
+nix = { version = "0.30.1", features = ["user"] }
 tar = "0.4.44"
 flate2 = "1.1.2"

--- a/src/tracer-installer/src/installer/install.rs
+++ b/src/tracer-installer/src/installer/install.rs
@@ -163,7 +163,7 @@ impl Installer {
             ".profile",
         ];
 
-        let home = dirs::home_dir().context("Could not find home directory")?;
+        let home = dirs_next::home_dir().context("Could not find home directory")?;
         let config_files = CONF_FILES
             .iter()
             .map(|name| home.join(name))

--- a/src/tracer/Cargo.toml
+++ b/src/tracer/Cargo.toml
@@ -33,7 +33,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 rand = { workspace = true }
 uuid = { workspace = true }
-dirs = { workspace = true }
 percent-encoding = { workspace = true }
 tokio-util = { workspace = true }
 aws-config = { workspace = true }
@@ -58,6 +57,7 @@ dashmap = { workspace = true }
 termion = { workspace = true }
 git2 = { workspace = true }
 which = { workspace = true }
+dirs-next = { workspace = true }
 
 [dev-dependencies]
 sqlx = { workspace = true }

--- a/src/tracer/src/cli/handlers/uninstall.rs
+++ b/src/tracer/src/cli/handlers/uninstall.rs
@@ -45,7 +45,7 @@ fn remove_binary() -> Result<()> {
     Ok(())
 }
 fn remove_env_paths() -> Result<()> {
-    let home_dir = dirs::home_dir().context("Failed to get home directory")?;
+    let home_dir = dirs_next::home_dir().context("Failed to get home directory")?;
 
     let profile_files = [".bashrc", ".bash_profile", ".zshrc", ".profile"];
     for profile in &profile_files {

--- a/src/tracer/src/config/defaults.rs
+++ b/src/tracer/src/config/defaults.rs
@@ -8,7 +8,7 @@ use crate::constants::{
 use crate::process_identification::constants::DEFAULT_DAEMON_PORT;
 
 fn get_aws_default_profile() -> String {
-    match dirs::home_dir() {
+    match dirs_next::home_dir() {
         None => "default",
         Some(path) => {
             if std::fs::read_to_string(path.join(".aws/credentials"))


### PR DESCRIPTION
The `dirs` crate is abandoned. `dirs-next` is a drop-in replacement.

## 🧪 Testing
To install tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | CLI_BRANCH="branch_name" sh`

To use the installer of tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | INS_BRANCH="branch_name" sh`


## 📌 Summary
<!-- Provide a concise summary of your changes -->

## 🔍 Related Issues/Tickets
<!-- Link to related issues or tickets, e.g., Closes #123 -->

## ✨ Changes Introduced
<!-- Briefly describe the changes in this PR -->

## ✨ Infrastructure Impact
<!-- Briefly describe if there is some impact to our infrastructure -->


## ✅ Checklist
- [ ] Code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and they work as expected
- [ ] Documentation has been updated if needed
- [ ] Tests have been added or updated

## 🛠️ How to Test
<!-- Provide instructions on how to test your changes -->

## 🚀 Screenshots (if applicable)
<!-- Add screenshots or GIFs to demonstrate the changes -->

## 📌 Additional Notes
<!-- Add any other relevant information -->
