### PR TITLE
Temporarily disable world writable check

### DIFF
--- a/src/tracer/src/utils/spawn.rs
+++ b/src/tracer/src/utils/spawn.rs
@@ -139,18 +139,20 @@ fn validate_path_secure(path: &Path) -> io::Result<()> {
     // Walk parents and ensure no component is world-writable.
     let mut cur = path;
     while let Some(dir) = cur.parent() {
-        let m = fs::metadata(dir)?;
-        #[cfg(unix)]
-        {
-            use os::unix::fs::MetadataExt;
-            let mode = m.mode();
-            if mode & 0o002 != 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "world-writable path component",
-                ));
-            }
-        }
+        // TODO: disabling this check for now as there are some environments we don't control
+        // (e.g. GitHub Actions) where the working directory is world-writable.
+        // #[cfg(unix)]
+        // {
+        //     use os::unix::fs::MetadataExt;
+        //     let m = fs::metadata(dir)?;
+        //     let mode = m.mode();
+        //     if mode & 0o002 != 0 {
+        //         return Err(io::Error::new(
+        //             io::ErrorKind::Other,
+        //             "world-writable path component",
+        //         ));
+        //     }
+        // }
         cur = dir;
         if cur.as_os_str().is_empty() {
             break;

--- a/src/tracer/src/utils/spawn.rs
+++ b/src/tracer/src/utils/spawn.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{self, Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::LazyLock;
-use std::{env, io, os};
+use std::{env, io};
 
 // TODO: implement code signature verification
 


### PR DESCRIPTION
As part of secure daemon spawing, best practice is to ensure that the binary is not installed in a world-writable directory, otherwise a non-privileged user could replace it with an arbitrary executable. However, on some platforms (e.g. GitHub actions) we don't control the permissions. Temporarily disabling this check and adding an issue to fix it.

## 🧪 Testing
To install tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | CLI_BRANCH="branch_name" sh`

To use the installer of tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | INS_BRANCH="branch_name" sh`


## 📌 Summary
<!-- Provide a concise summary of your changes -->

## 🔍 Related Issues/Tickets
<!-- Link to related issues or tickets, e.g., Closes #123 -->

## ✨ Changes Introduced
<!-- Briefly describe the changes in this PR -->

## ✨ Infrastructure Impact
<!-- Briefly describe if there is some impact to our infrastructure -->


## ✅ Checklist
- [ ] Code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and they work as expected
- [ ] Documentation has been updated if needed
- [ ] Tests have been added or updated

## 🛠️ How to Test
<!-- Provide instructions on how to test your changes -->

## 🚀 Screenshots (if applicable)
<!-- Add screenshots or GIFs to demonstrate the changes -->

## 📌 Additional Notes
<!-- Add any other relevant information -->
