### PR TITLE
feat: get container logs

### DIFF
--- a/src/tracer/src/opentelemetry/otel-config-template.yaml
+++ b/src/tracer/src/opentelemetry/otel-config-template.yaml
@@ -2,16 +2,10 @@ receivers:
   filelog:
     include:
       - "**/*.log"
-      - "**/*nextflow.log"
-      - "**/*nextflow*.log"
       - "**/*.nextflow.log"
-      - "**/*.nextflow.log.*"
-      - "**/*.nextflow.log*"
-      - "**/*.nextflow.log*"
-      - "**/*.nextflow.log*"
-      - "**/*.command.log"
       - "**/*.command.err"
       - "**/*.command.out"
+      - "/var/lib/docker/containers/**/*.log"
 
     exclude:
       - /proc/*


### PR DESCRIPTION
## 🧪 Testing
To install tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | CLI_BRANCH="feat/docker_logs" sh`

To use the installer of tracer with this version/branch, run:<br>
`curl -sSL https://install.tracer.cloud | INS_BRANCH="feat/docker_logs" sh`



