### PR TITLE
fix: allow rootless install and demo --force-procfs (#648)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,6 +4045,7 @@ dependencies = [
  "async-trait",
  "clap",
  "colored",
+ "dirs-next",
  "ec2_instance_metadata",
  "flate2",
  "futures-util",

--- a/README.md
+++ b/README.md
@@ -60,10 +60,16 @@ Start the Tracer client to initialize a pipeline and enable monitoring. You must
 - Get your token from the [Tracer Sandbox](https://app.tracer.cloud/)
 - Then run:
 
-> **Note:** Root privileges required
+> **Note:** Root gives the best experience (eBPF-based monitoring). Without root/sudo, add `--force-procfs` to run in rootless mode using `/proc` polling.
 
 ```bash
 sudo tracer init --token <paste-your-token-here> --watch-dir "/tmp/tracer"
+```
+
+Without root/sudo (rootless mode):
+
+```bash
+tracer init --token <paste-your-token-here> --watch-dir "/tmp/tracer" --force-procfs
 ```
 
 ### 4. Initialize a Pipeline
@@ -73,6 +79,12 @@ Run your own pipeline by following your usual workflow or try with one of our te
 
 ```bash
 sudo -E tracer demo
+```
+
+Without root/sudo (rootless mode):
+
+```bash
+tracer demo --force-procfs
 ```
 
 ### 5. Monitor Your Pipeline With Our Dashboard

--- a/src/tracer-installer/Cargo.toml
+++ b/src/tracer-installer/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 colored.workspace = true
+dirs-next.workspace = true
 ec2_instance_metadata.workspace = true
 flate2.workspace = true
 futures-util.workspace = true

--- a/src/tracer-installer/src/checks/mod.rs
+++ b/src/tracer-installer/src/checks/mod.rs
@@ -23,6 +23,12 @@ pub trait InstallCheck {
     fn name(&self) -> &'static str;
     fn error_message(&self) -> String;
     fn success_message(&self) -> String;
+
+    /// Whether a failure of this check should abort the install. Required checks (the default)
+    /// hard-fail; advisory checks only print a warning and let the install continue.
+    fn is_required(&self) -> bool {
+        true
+    }
 }
 
 pub struct CheckManager {
@@ -63,7 +69,7 @@ impl CheckManager {
     }
 
     pub async fn run_all(&self) {
-        let mut all_passed = true;
+        let mut required_failed = false;
 
         for check in &self.checks {
             if check.check().await {
@@ -73,16 +79,20 @@ impl CheckManager {
                     &check.success_message(),
                     TagColor::Green,
                 );
-            } else {
-                all_passed = false;
+            } else if check.is_required() {
+                required_failed = true;
                 let reason = check.error_message();
                 print_status("FAILED", check.name(), &reason, TagColor::Red);
+            } else {
+                // Advisory check: warn but let the install continue.
+                let reason = check.error_message();
+                print_status("WARNING", check.name(), &reason, TagColor::Cyan);
             }
         }
 
         println!(); // spacing after checks
 
-        if !all_passed {
+        if required_failed {
             error_message!("Required environment checks failed. Please contact support.");
             std::process::exit(1);
         }

--- a/src/tracer-installer/src/checks/root.rs
+++ b/src/tracer-installer/src/checks/root.rs
@@ -22,10 +22,29 @@ impl InstallCheck for RootCheck {
         "Root Privileges Access"
     }
     fn error_message(&self) -> String {
-        "Not Running As Root".into()
+        "Not running as root - installing to ~/.local/bin; run with `tracer init --force-procfs`"
+            .into()
     }
 
     fn success_message(&self) -> String {
         "Running As Root".into()
+    }
+
+    fn is_required(&self) -> bool {
+        // The daemon supports rootless operation via `tracer init --force-procfs`, so a
+        // non-root user should not be hard-gated. A failed root check is advisory only.
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_check_is_advisory_not_required() {
+        // A non-root user should not be hard-gated: the daemon supports rootless
+        // (`--force-procfs`) mode, so a failed root check is only a warning.
+        assert!(!RootCheck::new().is_required());
     }
 }

--- a/src/tracer-installer/src/fs.rs
+++ b/src/tracer-installer/src/fs.rs
@@ -33,8 +33,13 @@ impl TrustedDir {
         Ok(Self::Temp(tempfile::tempdir()?))
     }
 
-    pub fn usr_local_bin() -> Result<Self> {
-        Self::new(Path::new("/usr/local/bin"), Some("755"))
+    /// The directory the tracer binary is installed into given the current privilege level.
+    /// Root installs system-wide to `/usr/local/bin`; a non-root user installs to their own
+    /// `~/.local/bin` so rootless (`tracer init --force-procfs`) users can still get the binary
+    /// on disk instead of being hard-gated by the root check.
+    pub fn tracer_install_dir(is_root: bool) -> Result<Self> {
+        let path = install_dir_path(is_root, dirs_next::home_dir())?;
+        Self::new(&path, Some("755"))
     }
 
     /// Creates a new `TrustedDir` from an aribtrary path. The path must be sanitary. If the path
@@ -82,6 +87,21 @@ impl TrustedDir {
     {
         let path = self.as_path()?.join(subpath.try_into()?.into_path());
         Self::new(&path, None)
+    }
+}
+
+/// Resolve the directory the tracer binary should be installed into. Root installs system-wide
+/// to `/usr/local/bin`; a non-root user installs to `~/.local/bin`. Non-root without a
+/// resolvable home directory is an error (there is nowhere safe to place a user-local binary).
+fn install_dir_path(is_root: bool, home: Option<PathBuf>) -> Result<PathBuf> {
+    if is_root {
+        Ok(PathBuf::from("/usr/local/bin"))
+    } else {
+        let home = home.context(
+            "could not determine your home directory for a rootless install; \
+             re-run as root or set $HOME",
+        )?;
+        Ok(home.join(".local").join("bin"))
     }
 }
 
@@ -375,5 +395,23 @@ pub mod test {
         assert!(RelativePath::try_from(path).is_ok());
         let abs_path = Path::new("/absolute/path");
         assert!(RelativePath::try_from(abs_path).is_err());
+    }
+
+    #[test]
+    fn install_dir_root_is_system_wide() {
+        // Root installs system-wide regardless of home directory.
+        let path = install_dir_path(true, Some(PathBuf::from("/home/alice"))).unwrap();
+        assert_eq!(path, PathBuf::from("/usr/local/bin"));
+    }
+
+    #[test]
+    fn install_dir_nonroot_is_user_local_bin() {
+        let path = install_dir_path(false, Some(PathBuf::from("/home/alice"))).unwrap();
+        assert_eq!(path, PathBuf::from("/home/alice/.local/bin"));
+    }
+
+    #[test]
+    fn install_dir_nonroot_without_home_errors() {
+        assert!(install_dir_path(false, None).is_err());
     }
 }

--- a/src/tracer-installer/src/installer/install.rs
+++ b/src/tracer-installer/src/installer/install.rs
@@ -30,6 +30,16 @@ pub struct Installer {
     pub user_id: Option<String>,
 }
 
+/// The `tracer init` invocation to recommend after install. A rootless (non-root) install can't
+/// use the eBPF path, so it needs `--force-procfs`; a root install uses the default init.
+fn setup_command(is_root: bool) -> &'static str {
+    if is_root {
+        "tracer init"
+    } else {
+        "tracer init --force-procfs"
+    }
+}
+
 impl Installer {
     /// Executes the tracer binary download process:
     /// - Downloads the appropriate Tracer binary based on platform and version
@@ -37,6 +47,7 @@ impl Installer {
     /// - Updates shell configuration files to include Tracer in the PATH
     /// - Emits analytics events if a user ID is provided
     pub async fn run(&self) -> Result<()> {
+        let is_root = nix::unistd::Uid::effective().is_root();
         let mut analytics_handles = Vec::new();
 
         if let Some(handle) = self
@@ -56,7 +67,7 @@ impl Installer {
             .download_and_extract_tarball(&url, &temp_dir, "tracer.tar.gz", "extracted")
             .await?;
 
-        let _ = self.install_to_final_dir(&extract_path)?;
+        let installed_path = self.install_to_final_dir(&extract_path, is_root)?;
 
         if let Some(handle) = self
             .emit_analytic_event(AnalyticsEventType::InstallScriptCompleted)
@@ -65,7 +76,7 @@ impl Installer {
             analytics_handles.push(handle);
         }
 
-        self.print_next_steps();
+        self.print_next_steps(is_root, &installed_path);
         join_all(analytics_handles).await;
         Ok(())
     }
@@ -132,9 +143,13 @@ impl Installer {
         Ok(())
     }
 
-    fn install_to_final_dir(&self, extracted_dir: &TrustedDir) -> Result<TrustedFile> {
+    fn install_to_final_dir(
+        &self,
+        extracted_dir: &TrustedDir,
+        is_root: bool,
+    ) -> Result<TrustedFile> {
         let extracted_binary = extracted_dir.join_file("tracer")?;
-        let tracer_installation_dir = TrustedDir::usr_local_bin()?;
+        let tracer_installation_dir = TrustedDir::tracer_install_dir(is_root)?;
         let final_path = tracer_installation_dir.join_file("tracer")?;
 
         extracted_binary
@@ -208,7 +223,7 @@ impl Installer {
         }))
     }
 
-    pub fn print_next_steps(&self) {
+    pub fn print_next_steps(&self, is_root: bool, installed_path: &TrustedFile) {
         let sandbox_url = if self.channel == TracerVersion::Production {
             TRACER_SANDBOX_ENDPOINT_PROD
         } else {
@@ -226,21 +241,37 @@ impl Installer {
         println!("  {}\n", "https://www.tracer.cloud/docs".cyan());
 
         println!("- {} Initialize Tracer:", "Setup".bold().yellow());
-        println!("  {}\n", "tracer init".cyan());
+        println!("  {}\n", setup_command(is_root).cyan());
+        if !is_root {
+            println!(
+                "  Installed to {}. Make sure {} is on your PATH.\n",
+                installed_path.to_string().cyan(),
+                "~/.local/bin".cyan()
+            );
+        }
 
         println!("- {} Check daemon status:", "Status".bold().yellow());
         println!("  {}\n", "tracer info".cyan());
-
-        if !nix::unistd::Uid::effective().is_root() {
-            println!("- {} Set up elevated privileges:", "Required:".yellow());
-            println!("  {}\n", "sudo chown root ~/.tracerbio/bin/tracer".cyan());
-            println!("  {}\n", "sudo chmod u+s ~/.tracerbio/bin/tracer".cyan());
-        }
 
         println!(
             "- {} Need help? Email us at {}\n",
             "Support".green(),
             "support@tracer.cloud".cyan()
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setup_command_root_uses_plain_init() {
+        assert_eq!(setup_command(true), "tracer init");
+    }
+
+    #[test]
+    fn setup_command_rootless_uses_force_procfs() {
+        assert_eq!(setup_command(false), "tracer init --force-procfs");
     }
 }

--- a/src/tracer/src/cli/handlers/demo/arguments.rs
+++ b/src/tracer/src/cli/handlers/demo/arguments.rs
@@ -71,6 +71,11 @@ pub struct DemoInitArgs {
     /// Input prompts: [none|minimal|required] (default: minimal)
     #[clap(short = 'i', long, default_value = "minimal")]
     pub interactive: crate::cli::handlers::init::arguments::PromptMode,
+
+    /// force process polling even if eBPF is available; this enables you to use
+    /// the client without having root/sudo privileges
+    #[clap(long)]
+    pub force_procfs: bool,
 }
 
 impl DemoInitArgs {
@@ -80,6 +85,7 @@ impl DemoInitArgs {
             pipeline_name: self.pipeline_name,
             run_name: self.run_name,
             interactive_prompts: self.interactive,
+            force_procfs: self.force_procfs,
             tags: PipelineTags {
                 environment: self.environment,
                 instance_type: self.instance_type,
@@ -114,5 +120,26 @@ impl TracerCliDemoArgs {
         // Since we removed the command structure, we need a different way to handle list
         // For now, we'll check if the pipeline_id is "list"
         self.demo_pipeline_id.as_deref() == Some("list")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn force_procfs_propagates_to_init_args() {
+        // `tracer demo --force-procfs` must reach init so rootless users can run the demo.
+        let demo = DemoInitArgs {
+            force_procfs: true,
+            ..Default::default()
+        };
+        assert!(demo.to_full_init_args().force_procfs);
+    }
+
+    #[test]
+    fn force_procfs_defaults_to_false() {
+        let demo = DemoInitArgs::default();
+        assert!(!demo.to_full_init_args().force_procfs);
     }
 }


### PR DESCRIPTION
## What & why

Closes part of #648. The daemon already supports rootless operation via `tracer init --force-procfs`, but the **installer** and **`tracer demo`** never caught up — a non-root user (laptop, codespace, rootless container) is hard-gated at the env-check before the binary ever lands on disk, even though the runtime would support them.

> ⚠️ Draft / coordination: @WatchTree-19 filed #648 and offered to take all four parts. I picked it up as a first contribution — happy to hand off, split, or combine if you're already on it. cc @VaibhavUpreti @tiagonix

## Changes

**Installer (`tracer-installer`)**
- Root check is now **advisory** instead of fatal, via a new `InstallCheck::is_required()` (defaults to `true`; `RootCheck` overrides to `false`). Non-root users see a `WARNING` and the install continues.
- Non-root installs now target **`~/.local/bin/tracer`** instead of `/usr/local/bin` — the same location the updater already probes (`update/updater.rs`). Root installs are unchanged (`/usr/local/bin`).
- Post-install **"Next steps"** now prints the *real* install path and a rootless `tracer init --force-procfs` hint, replacing the stale `~/.tracerbio/bin/tracer` chown/chmod block (that was a third, nonexistent path).

**CLI (`tracer`)**
- `tracer demo` gains **`--force-procfs`**, propagated into the init args. The flag was already documented in `demo --help-advanced` but not wired to a struct field, so it errored with `unexpected argument`. Now it works.

**Docs**
- README documents the rootless (`--force-procfs`) path for both `init` and `demo`.

## On part 2 of the issue (`--interactive-prompts none` hang)

Already fixed on `main` — the auth path exits non-zero **without** prompting. Verified with the issue's exact repro:

```
$ tracer init --force-procfs --interactive-prompts none --pipeline-name x
Unable to log in automatically. Please open https://.../ and copy your init code here.
$ echo $?
1
```

So no change was needed there.

## Testing

- **New unit tests (TDD)**: install-dir selection (root vs. `~/.local/bin` vs. no-home error), `RootCheck` is advisory, post-install `setup_command`, and `demo --force-procfs` propagation.
- **Runtime-verified** on macOS: `tracer demo --force-procfs --help-advanced` now parses (exit 0); an unknown flag still errors; the init repro above exits `1` fast.
- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and the changed-crate test suites all pass on the pinned toolchain (1.91.1).

## Open question for maintainers

`tracer info` shows `tracer login && tracer init` while the README leads with `sudo tracer init --token …`. #648 flags this as a fourth inconsistency. I left `tracer info` untouched to avoid changing product copy unilaterally — happy to align it either way if you have a preferred happy path.
